### PR TITLE
Add custom config file and  custom additional pgBackRest configuration files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Flags:
   --prom.port="9854"          Port for prometheus metrics to listen on.
   --prom.endpoint="/metrics"  Endpoint used for metrics.
   --collect.interval=600      Collecting metrics interval in seconds.
+  --backrest.config=""        Non default pgBackRest configuration file.
+  --backrest.config-include-path=""  
+                              Non default path to additional pgBackRest configuration files.
   --verbose.info              Enable additional metrics labels.
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,6 @@ The metrics provided by the client.
     - 0 - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,
     - 1 - both WALMin and WALMax have no empty values, there is correct information about WAL archiving.
 
-    When flag `--verbose.info` is specified - WALMin and WALMax are added as metric labels.
-    This creates new different time series on each WAL archiving.
-
 ## Getting Started
 ### Building and running
 
@@ -71,11 +68,19 @@ Flags:
   --prom.port="9854"          Port for prometheus metrics to listen on.
   --prom.endpoint="/metrics"  Endpoint used for metrics.
   --collect.interval=600      Collecting metrics interval in seconds.
-  --backrest.config=""        Non default pgBackRest configuration file.
+  --backrest.config=""        Full path to pgBackRest configuration file.
   --backrest.config-include-path=""  
-                              Non default path to additional pgBackRest configuration files.
+                              Full path to additional pgBackRest configuration files.
   --verbose.info              Enable additional metrics labels.
 ```
+
+#### Additional description of flags.
+
+Custom `config` and/or custom `config-include-path` for `pgbackrest` command could be specify via `--backrest.config` and `--backrest.config-include-path` flags. 
+Full paths must be specified. For example, `--backrest.config=/tmp/pgbackrest.conf` and/or `--backrest.config-include-path=/tmp/pgbackrest/conf.d`.
+
+When flag `--verbose.info` is specified - WALMin and WALMax are added as metric labels.
+This creates new different time series on each WAL archiving.
 
 ### Building and running docker
 By default, pgBackRest version is `2.34`. Another version can be specified via arguments.

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -27,8 +27,8 @@ func StartPromEndpoint() {
 }
 
 // GetPgBackRestInfo get and parse pgbackrest info
-func GetPgBackRestInfo(verbose bool) error {
-	stanzaData, err := getAllInfoData()
+func GetPgBackRestInfo(config, configIncludePath string, verbose bool) error {
+	stanzaData, err := getAllInfoData(config, configIncludePath)
 	if err != nil {
 		log.Printf("[ERROR] Get data from pgbackrest failed, %v.", err)
 		resetMetrics()

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -26,7 +26,9 @@ func TestSetPromPortandPath(t *testing.T) {
 
 func TestGetPgBackRestInfo(t *testing.T) {
 	type args struct {
-		verbose bool
+		config            string
+		configIncludePath string
+		verbose           bool
 	}
 	tests := []struct {
 		name       string
@@ -36,7 +38,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 		wantErr    bool
 	}{
 		{"GetPgBackRestInfoGoodDataReturn",
-			args{false},
+			args{"", "", false},
 			`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 				`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
 				`"backup":[{"archive":{"start":"000000010000000000000002","stop":"000000010000000000000002"},` +
@@ -50,20 +52,35 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			0,
 			false},
 		{"GetPgBackRestInfoBadDataReturn",
-			args{false},
+			args{"", "", false},
 			`Forty two`,
 			1,
 			true},
 		{"GetPgBackRestInfoZeroDataReturn",
-			args{false},
+			args{"", "", false},
 			`[]`,
 			0,
 			false},
 		{"GetPgBackRestInfoJsonUnmarshalFail",
-			args{false},
+			args{"", "", false},
 			`[{}`,
 			0,
 			true},
+		{"GetPgBackRestInfoConfig",
+			args{"/tmp/pgbackrest.conf", "", false},
+			`[]`,
+			0,
+			false},
+		{"GetPgBackRestInfoConfigIncludePath",
+			args{"", "/tmp/pgbackrest/conf.d", false},
+			`[]`,
+			0,
+			false},
+		{"GetPgBackRestInfoConfigAndConfigIncludePath",
+			args{"/tmp/pgbackrest.conf", "/tmp/pgbackrest/conf.d", false},
+			`[]`,
+			0,
+			false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -71,7 +88,11 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			execCommand = fakeExecCommand
 			mockExit = tt.mockExit
 			defer func() { execCommand = exec.Command }()
-			if err := GetPgBackRestInfo(tt.args.verbose); (err != nil) != tt.wantErr {
+			if err := GetPgBackRestInfo(
+				tt.args.config,
+				tt.args.configIncludePath,
+				tt.args.verbose,
+			); (err != nil) != tt.wantErr {
 				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", err, tt.wantErr)
 			}
 		})

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -320,8 +321,87 @@ func TestSetUpMetricValue(t *testing.T) {
 	}
 }
 
+func TestReturnDefaultExecArgs(t *testing.T) {
+	testArgs := []string{"info", "--output", "json"}
+	defaultArgs := returnDefaultExecArgs()
+	if !reflect.DeepEqual(testArgs, defaultArgs) {
+		t.Errorf("\nVariables do not match: %s,\nwant: %s", testArgs, defaultArgs)
+	}
+}
+
+func TestReturnConfigExecArgs(t *testing.T) {
+	type args struct {
+		config            string
+		configIncludePath string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"returnConfigExecArgsEmpty",
+			args{"", ""},
+			[]string{},
+		},
+		{"returnConfigExecArgsNotEmptyConfig",
+			args{"/tmp/pgbackrest.conf", ""},
+			[]string{"--config", "/tmp/pgbackrest.conf"},
+		},
+		{"returnConfigExecArgsNotEmptyConfigInckudePath",
+			args{"", "/tmp/pgbackrest/conf.d"},
+			[]string{"--config-include-path", "/tmp/pgbackrest/conf.d"},
+		},
+		{"returnConfigExecArgsNotEmptyConfigAndConfigInckudePath",
+			args{"/tmp/pgbackrest.conf", "/tmp/pgbackrest/conf.d"},
+			[]string{"--config", "/tmp/pgbackrest.conf", "--config-include-path", "/tmp/pgbackrest/conf.d"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := returnConfigExecArgs(tt.args.config, tt.args.configIncludePath); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConcatExecArgs(t *testing.T) {
+	type args struct {
+		slices [][]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"concatExecArgsEmpty",
+			args{[][]string{{}, {}}},
+			[]string{},
+		},
+		{"concatExecArgsNotEmptyAndEmpty",
+			args{[][]string{{"test", "data"}, {}}},
+			[]string{"test", "data"},
+		},
+		{"concatExecArgsEmptyAndNotEmpty",
+			args{[][]string{{}, {"test", "data"}}},
+			[]string{"test", "data"},
+		},
+		{"concatExecArgsNotEmpty",
+			args{[][]string{{"the", "best"}, {"test", "data"}}},
+			[]string{"the", "best", "test", "data"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := concatExecArgs(tt.args.slices); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
 func fakeSetUpMetricValue(metric *prometheus.GaugeVec, value float64, labels ...string) error {
-	return errors.New("Custorm error for test")
+	return errors.New("сustorm error for test")
 }
 
 //nolint:unparam

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -30,11 +30,11 @@ func main() {
 		).Default("600").Int()
 		backrestCustomConfig = kingpin.Flag(
 			"backrest.config",
-			"Non default pgBackRest configuration file.",
+			"Full path to pgBackRest configuration file.",
 		).Default("").String()
 		backrestCustomConfigIncludePath = kingpin.Flag(
 			"backrest.config-include-path",
-			"Non default path to additional pgBackRest configuration files.",
+			"Full path to additional pgBackRest configuration files.",
 		).Default("").String()
 		verboseInfo = kingpin.Flag(
 			"verbose.info",

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -28,6 +28,14 @@ func main() {
 			"collect.interval",
 			"Collecting metrics interval in seconds.",
 		).Default("600").Int()
+		backrestCustomConfig = kingpin.Flag(
+			"backrest.config",
+			"Non default pgBackRest configuration file.",
+		).Default("").String()
+		backrestCustomConfigIncludePath = kingpin.Flag(
+			"backrest.config-include-path",
+			"Non default path to additional pgBackRest configuration files.",
+		).Default("").String()
 		verboseInfo = kingpin.Flag(
 			"verbose.info",
 			"Enable additional metrics labels.",
@@ -50,6 +58,12 @@ func main() {
 	log.Printf("[INFO] Version %s.", version)
 	log.Printf("[INFO] Verbose info %t.", *verboseInfo)
 	log.Printf("[INFO] Collecting metrics every %d seconds.", *collectionInterval)
+	if *backrestCustomConfig != "" {
+		log.Printf("[INFO] Custom pgBackRest configuration file %s.", *backrestCustomConfig)
+	}
+	if *backrestCustomConfigIncludePath != "" {
+		log.Printf("[INFO] Custom path to additional pgBackRest configuration files %s.", *backrestCustomConfig)
+	}
 	// Setup parameters for exporter.
 	backrest.SetPromPortandPath(*promPort, *promPath)
 	log.Printf("[INFO] Use port %s and HTTP endpoint %s.", *promPort, *promPath)
@@ -57,7 +71,11 @@ func main() {
 	backrest.StartPromEndpoint()
 	for {
 		// Get information form pgbackrest.
-		err := backrest.GetPgBackRestInfo(*verboseInfo)
+		err := backrest.GetPgBackRestInfo(
+			*backrestCustomConfig,
+			*backrestCustomConfigIncludePath,
+			*verboseInfo,
+		)
 		if err != nil {
 			log.Printf("[ERROR] Get data failed, %v.", err)
 		}

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -62,7 +62,7 @@ func main() {
 		log.Printf("[INFO] Custom pgBackRest configuration file %s.", *backrestCustomConfig)
 	}
 	if *backrestCustomConfigIncludePath != "" {
-		log.Printf("[INFO] Custom path to additional pgBackRest configuration files %s.", *backrestCustomConfig)
+		log.Printf("[INFO] Custom path to additional pgBackRest configuration files %s.", *backrestCustomConfigIncludePath)
 	}
 	// Setup parameters for exporter.
 	backrest.SetPromPortandPath(*promPort, *promPath)


### PR DESCRIPTION
Added the ability to specify  pgBackRest configuration file and/or path to additional pgBackRest configuration files.

 Flags:
 * `backrest.config` - full path to pgBackRest configuration file, by default - `""`;
 * `backrest.config-include-path` - full path to additional pgBackRest configuration files,  by default - `""`.
 
If flags are not specified, the standard pgBackRest paths are used.

Also a small refactoring was performed and the README was updated.