### PR TITLE
Add speciific stanza.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}
 ARG REPO_BUILD_TAG
 ENV EXPORTER_ENDPOINT="/metrics" \
     EXPORTER_PORT="9854" \
+    STANZA="" \
     COLLECT_INTERVAL="600"
 COPY --from=builder /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter
 RUN chmod 755 /etc/pgbackrest/pgbackrest_exporter
@@ -24,5 +25,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD /etc/pgbackrest/pgbackrest_exporter \
         --prom.endpoint=${EXPORTER_ENDPOINT} \
         --prom.port=${EXPORTER_PORT} \
+        --backrest.stanza=${STANZA} \
         --collect.interval=${COLLECT_INTERVAL}
 EXPOSE ${EXPORTER_PORT}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Flags:
   --backrest.config=""        Full path to pgBackRest configuration file.
   --backrest.config-include-path=""  
                               Full path to additional pgBackRest configuration files.
-  --backrest.stanza="" ...    Specific stanza to collect metrics. Can be specified several times.
+  --backrest.stanza="" ...    Specific stanza for collecting metrics. Can be specified several times.
   --verbose.info              Enable additional metrics labels.
 ```
 
@@ -105,6 +105,7 @@ Environment variables supported by this image:
 * all environment variables from [docker-pgbackrest](https://github.com/woblerr/docker-pgbackrest#docker-pgbackrest)  image;
 * `EXPORTER_ENDPOINT` - metrics endpoint, default `/metrics`;
 * `EXPORTER_PORT` - port for prometheus metrics to listen on, default `9854`;
+* `STANZA` - 
 * `COLLECT_INTERVAL` - collecting metrics interval in seconds, default `600`;
 
 You will need to mount the necessary directories or files inside the container.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Prometheus exporter for [pgBackRest](https://pgbackrest.org/).
 
-The metrics are collected by parsing result of `pgbackrest info --output json` command. The metrics are collected for all stanzas received by command. You need to run exporter on the same host where pgBackRest was installed or inside Docker.
+The metrics are collected based on result of `pgbackrest info --output json` command. By default, the metrics are collected for all stanzas received by command. You can specify stanzas to collect metrics. You need to run exporter on the same host where pgBackRest was installed or inside Docker.
 
 All metrics are collected for `pgBackRest >= v2.32`.
 For earlier versions, some metrics may not be collected or have insignificant label values.
@@ -71,13 +71,18 @@ Flags:
   --backrest.config=""        Full path to pgBackRest configuration file.
   --backrest.config-include-path=""  
                               Full path to additional pgBackRest configuration files.
+  --backrest.stanza="" ...    Specific stanza to collect metrics. Can be specified several times.
   --verbose.info              Enable additional metrics labels.
 ```
 
 #### Additional description of flags.
 
-Custom `config` and/or custom `config-include-path` for `pgbackrest` command could be specify via `--backrest.config` and `--backrest.config-include-path` flags. 
+Custom `config` and/or custom `config-include-path` for `pgbackrest` command can be specified via `--backrest.config` and `--backrest.config-include-path` flags. 
 Full paths must be specified. For example, `--backrest.config=/tmp/pgbackrest.conf` and/or `--backrest.config-include-path=/tmp/pgbackrest/conf.d`.
+
+Custom `stanza` for collecting metrics can be specified via `--backrest.stanza` flag. 
+You can specify several stanzas. For example, `--backrest.stanza=demo1 --backrest.stanza=demo2`.
+For this case, metrics will be collected only for `demo1` and `demo2` stanzas.
 
 When flag `--verbose.info` is specified - WALMin and WALMax are added as metric labels.
 This creates new different time series on each WAL archiving.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Environment variables supported by this image:
 * all environment variables from [docker-pgbackrest](https://github.com/woblerr/docker-pgbackrest#docker-pgbackrest)  image;
 * `EXPORTER_ENDPOINT` - metrics endpoint, default `/metrics`;
 * `EXPORTER_PORT` - port for prometheus metrics to listen on, default `9854`;
-* `STANZA` - 
+* `STANZA` - specific stanza for collecting metrics, default `""`;
 * `COLLECT_INTERVAL` - collecting metrics interval in seconds, default `600`;
 
 You will need to mount the necessary directories or files inside the container.
@@ -136,6 +136,35 @@ docker run -d \
     pgbackrest_exporter
 ```
 
+For specific stanza:
+
+```bash
+docker run -d \
+    --name pgbackrest_exporter \
+    -e STANZA=demo \
+    -p 9854:9854 \
+    -v  /etc/pgbackrest/pgbackrest.conf:/etc/pgbackrest/pgbackrest.conf \
+    pgbackrest_exporter
+```
+
+If you want to specify several stanzas for collecting metrics, 
+you can run containers on different ports:
+
+```bash
+docker run -d \
+    --name pgbackrest_exporter_demo1 \
+    -e STANZA=demo1 \
+    -p 9854:9854 \
+    -v  /etc/pgbackrest/pgbackrest.conf:/etc/pgbackrest/pgbackrest.conf \
+    pgbackrest_exporter
+
+docker run -d \
+    --name pgbackrest_exporter_demo2 \
+    -e STANZA=demo2 \
+    -p 9855:9854 \
+    -v  /etc/pgbackrest/pgbackrest.conf:/etc/pgbackrest/pgbackrest.conf \
+    pgbackrest_exporter
+```
 ### Running as systemd service
 
 * Register `pgbackrest_exporter` (already builded, if not - exec `make build` before) as a systemd service:

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -26,24 +26,34 @@ func StartPromEndpoint() {
 	}()
 }
 
-// GetPgBackRestInfo get and parse pgbackrest info
-func GetPgBackRestInfo(config, configIncludePath string, verbose bool) error {
-	stanzaData, err := getAllInfoData(config, configIncludePath)
+// ResetMetrics reset metrics
+func ResetMetrics() {
+	pgbrStanzaStatusMetric.Reset()
+	pgbrRepoStatusMetric.Reset()
+	pgbrStanzaBackupInfoMetric.Reset()
+	pgbrStanzaBackupDurationMetric.Reset()
+	pgbrStanzaBackupDatabaseSizeMetric.Reset()
+	pgbrStanzaBackupDatabaseBackupSizeMetric.Reset()
+	pgbrStanzaBackupRepoBackupSetSizeMetric.Reset()
+	pgbrStanzaBackupRepoBackupSizeMetric.Reset()
+	pgbrWALArchivingMetric.Reset()
+}
+
+// GetPgBackRestInfo get and parse pgbackrest info and set metrics
+func GetPgBackRestInfo(config, configIncludePath, stanza string, verbose bool) error {
+	stanzaData, err := getAllInfoData(config, configIncludePath, stanza)
 	if err != nil {
 		log.Printf("[ERROR] Get data from pgbackrest failed, %v.", err)
-		resetMetrics()
 		return err
 	}
 	parseStanzaData, err := parseResult(stanzaData)
 	if err != nil {
 		log.Printf("[ERROR] Parse JSON failed, %v.", err)
-		resetMetrics()
 		return err
 	}
 	if len(parseStanzaData) == 0 {
 		log.Printf("[WARN] No backup data returned.")
 	}
-	resetMetrics()
 	for _, singleStanza := range parseStanzaData {
 		getMetrics(singleStanza, verbose, setUpMetricValue)
 	}

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -28,6 +28,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 	type args struct {
 		config            string
 		configIncludePath string
+		stanza            string
 		verbose           bool
 	}
 	tests := []struct {
@@ -38,7 +39,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 		wantErr    bool
 	}{
 		{"GetPgBackRestInfoGoodDataReturn",
-			args{"", "", false},
+			args{"", "", "", false},
 			`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 				`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
 				`"backup":[{"archive":{"start":"000000010000000000000002","stop":"000000010000000000000002"},` +
@@ -52,32 +53,37 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			0,
 			false},
 		{"GetPgBackRestInfoBadDataReturn",
-			args{"", "", false},
+			args{"", "", "", false},
 			`Forty two`,
 			1,
 			true},
 		{"GetPgBackRestInfoZeroDataReturn",
-			args{"", "", false},
+			args{"", "", "", false},
 			`[]`,
 			0,
 			false},
 		{"GetPgBackRestInfoJsonUnmarshalFail",
-			args{"", "", false},
+			args{"", "", "", false},
 			`[{}`,
 			0,
 			true},
 		{"GetPgBackRestInfoConfig",
-			args{"/tmp/pgbackrest.conf", "", false},
+			args{"/tmp/pgbackrest.conf", "", "", false},
 			`[]`,
 			0,
 			false},
 		{"GetPgBackRestInfoConfigIncludePath",
-			args{"", "/tmp/pgbackrest/conf.d", false},
+			args{"", "/tmp/pgbackrest/conf.d", "", false},
 			`[]`,
 			0,
 			false},
 		{"GetPgBackRestInfoConfigAndConfigIncludePath",
-			args{"/tmp/pgbackrest.conf", "/tmp/pgbackrest/conf.d", false},
+			args{"/tmp/pgbackrest.conf", "/tmp/pgbackrest/conf.d", "", false},
+			`[]`,
+			0,
+			false},
+		{"GetPgBackRestInfoStanzaPath",
+			args{"", "", "demo", false},
 			`[]`,
 			0,
 			false},
@@ -91,6 +97,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			if err := GetPgBackRestInfo(
 				tt.args.config,
 				tt.args.configIncludePath,
+				tt.args.stanza,
 				tt.args.verbose,
 			); (err != nil) != tt.wantErr {
 				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", err, tt.wantErr)

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -143,13 +143,24 @@ func returnConfigExecArgs(config, configIncludePath string) []string {
 	case config == "" && configIncludePath != "":
 		// Use custom config-include-path.
 		configArgs = []string{"--config-include-path", configIncludePath}
-	case config != "" && configIncludePath != "":
+	default:
 		// Use custom config and config-include-path.
 		configArgs = []string{"--config", config, "--config-include-path", configIncludePath}
-	default:
-		// Do nothing.
 	}
 	return configArgs
+}
+
+func returnConfigStanzaArgs(stanza string) []string {
+	var stanzaArgs []string
+	switch {
+	case stanza == "":
+		// Stanza not set. No return parametrs.
+		stanzaArgs = []string{}
+	default:
+		// Use specific stanza.
+		stanzaArgs = []string{"--stanza", stanza}
+	}
+	return stanzaArgs
 }
 
 func concatExecArgs(slices [][]string) []string {
@@ -160,11 +171,12 @@ func concatExecArgs(slices [][]string) []string {
 	return tmp
 }
 
-func getAllInfoData(config, configIncludePath string) ([]byte, error) {
+func getAllInfoData(config, configIncludePath, stanza string) ([]byte, error) {
 	app := "pgbackrest"
 	args := [][]string{
 		returnDefaultExecArgs(),
 		returnConfigExecArgs(config, configIncludePath),
+		returnConfigStanzaArgs(stanza),
 	}
 	// Finally arguments for exec command
 	concatArgs := concatExecArgs(args)
@@ -175,18 +187,6 @@ func getAllInfoData(config, configIncludePath string) ([]byte, error) {
 func parseResult(output []byte) ([]stanza, error) {
 	err := json.Unmarshal(output, &stanzas)
 	return stanzas, err
-}
-
-func resetMetrics() {
-	pgbrStanzaStatusMetric.Reset()
-	pgbrRepoStatusMetric.Reset()
-	pgbrStanzaBackupInfoMetric.Reset()
-	pgbrStanzaBackupDurationMetric.Reset()
-	pgbrStanzaBackupDatabaseSizeMetric.Reset()
-	pgbrStanzaBackupDatabaseBackupSizeMetric.Reset()
-	pgbrStanzaBackupRepoBackupSetSizeMetric.Reset()
-	pgbrStanzaBackupRepoBackupSizeMetric.Reset()
-	pgbrWALArchivingMetric.Reset()
 }
 
 func getPGVersion(id, repoKey int, dbList []db) string {

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -84,6 +84,7 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ResetMetrics()
 			getMetrics(tt.args.data, tt.args.verbose, tt.args.setUpMetricValueFun)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
@@ -110,7 +111,6 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 			if tt.args.testText != out.String() {
 				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", tt.args.testText, out.String())
 			}
-			resetMetrics()
 		})
 	}
 }
@@ -163,6 +163,7 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ResetMetrics()
 			getMetrics(tt.args.data, tt.args.verbose, tt.args.setUpMetricValueFun)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
@@ -189,7 +190,6 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 			if tt.args.testText != out.String() {
 				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", tt.args.testText, out.String())
 			}
-			resetMetrics()
 		})
 	}
 }
@@ -359,6 +359,33 @@ func TestReturnConfigExecArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := returnConfigExecArgs(tt.args.config, tt.args.configIncludePath); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReturnConfigStanzaArgs(t *testing.T) {
+	type args struct {
+		stanza string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"returnStanzaExecArgsEmpty",
+			args{""},
+			[]string{},
+		},
+		{"returnStanzaExecArgsNotEmpty",
+			args{"demo"},
+			[]string{"--stanza", "demo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := returnConfigStanzaArgs(tt.args.stanza); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", got, tt.want)
 			}
 		})

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -39,7 +39,7 @@ func main() {
 		).Default("").String()
 		backrestStanza = kingpin.Flag(
 			"backrest.stanza",
-			"Specific stanza to collect metrics. Can be specified several times.",
+			"Specific stanza for collecting metrics. Can be specified several times.",
 		).Default("").PlaceHolder("\"\"").Strings()
 		verboseInfo = kingpin.Flag(
 			"verbose.info",


### PR DESCRIPTION
Added the ability to specify one or multiple stanzas for collecting metrics.

Flag `backrest.stanza` - specific stanza for collecting metrics, by default - `""`. Can be specified several times.

For Docker image - added env variable `STANZA`.

Updated README.