### PR TITLE
Add exclude stanza option.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}
 ARG REPO_BUILD_TAG
 ENV EXPORTER_ENDPOINT="/metrics" \
     EXPORTER_PORT="9854" \
-    STANZA="" \
+    STANZA_INCLUDE="" \
+    STANZA_EXCLUDE="" \
     COLLECT_INTERVAL="600"
 COPY --from=builder /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter
 RUN chmod 755 /etc/pgbackrest/pgbackrest_exporter
@@ -25,6 +26,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD /etc/pgbackrest/pgbackrest_exporter \
         --prom.endpoint=${EXPORTER_ENDPOINT} \
         --prom.port=${EXPORTER_PORT} \
-        --backrest.stanza-include=${STANZA} \
+        --backrest.stanza-include=${STANZA_INCLUDE} \
+        --backrest.stanza-exclude=${STANZA_EXCLUDE} \
         --collect.interval=${COLLECT_INTERVAL}
 EXPOSE ${EXPORTER_PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD /etc/pgbackrest/pgbackrest_exporter \
         --prom.endpoint=${EXPORTER_ENDPOINT} \
         --prom.port=${EXPORTER_PORT} \
-        --backrest.stanza=${STANZA} \
+        --backrest.stanza-include=${STANZA} \
         --collect.interval=${COLLECT_INTERVAL}
 EXPOSE ${EXPORTER_PORT}

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Flags:
   --backrest.config=""        Full path to pgBackRest configuration file.
   --backrest.config-include-path=""  
                               Full path to additional pgBackRest configuration files.
-  --backrest.stanza="" ...    Specific stanza for collecting metrics. Can be specified several times.
+  --backrest.stanza-include="" ...  
+                              Specific stanza for collecting metrics. Can be specified several times.
   --verbose.info              Enable additional metrics labels.
 ```
 
@@ -83,8 +84,8 @@ Flags:
 Custom `config` and/or custom `config-include-path` for `pgbackrest` command can be specified via `--backrest.config` and `--backrest.config-include-path` flags. 
 Full paths must be specified. For example, `--backrest.config=/tmp/pgbackrest.conf` and/or `--backrest.config-include-path=/tmp/pgbackrest/conf.d`.
 
-Custom `stanza` for collecting metrics can be specified via `--backrest.stanza` flag. 
-You can specify several stanzas. For example, `--backrest.stanza=demo1 --backrest.stanza=demo2`.
+Custom `stanza` for collecting metrics can be specified via `--backrest.stanza-include` flag. 
+You can specify several stanzas. For example, `--backrest.stanza-include=demo1 --backrest.stanza-include=demo2`.
 For this case, metrics will be collected only for `demo1` and `demo2` stanzas.
 
 When flag `--verbose.info` is specified - WALMin and WALMax are added as metric labels.

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -44,26 +44,36 @@ func ResetMetrics() {
 }
 
 // GetPgBackRestInfo get and parse pgBackRest info and set metrics
-func GetPgBackRestInfo(config, configIncludePath string, stanzas []string, verbose bool) {
+func GetPgBackRestInfo(config, configIncludePath string, stanzas []string, stanzasExclude []string, verbose bool) {
 	// To calculate the time elapsed since the last completed full, differential or incremental backup.
 	// For all stanzas values are calculated relative to one value.
 	currentUnixTime := time.Now().Unix()
 	// Loop over each stanza.
 	// If stanza not set - perform a single loop step to get metrics for all stanzas.
 	for _, stanza := range stanzas {
-		stanzaData, err := getAllInfoData(config, configIncludePath, stanza)
-		if err != nil {
-			log.Printf("[ERROR] Get data from pgBackRest failed, %v", err)
+		// Check that stanza from the include list is not in the exclude list.
+		// If stanza not set - checking for entry into the exclude list will be performed later.
+		if stanzaNotInExclude(stanza, stanzasExclude) {
+			stanzaData, err := getAllInfoData(config, configIncludePath, stanza)
+			if err != nil {
+				log.Printf("[ERROR] Get data from pgBackRest failed, %v", err)
+			}
+			parseStanzaData, err := parseResult(stanzaData)
+			if err != nil {
+				log.Printf("[ERROR] Parse JSON failed, %v", err)
+			}
+			if len(parseStanzaData) == 0 {
+				log.Printf("[WARN] No backup data returned")
+			}
+			for _, singleStanza := range parseStanzaData {
+				// If stanza is in the exclude list, skip it.
+				if stanzaNotInExclude(singleStanza.Name, stanzasExclude) {
+					getMetrics(singleStanza, verbose, currentUnixTime, setUpMetricValue)
+				}
+			}
+		} else {
+			log.Printf("[WARN] Stanza %s is specified in include and exclude lists", stanza)
 		}
-		parseStanzaData, err := parseResult(stanzaData)
-		if err != nil {
-			log.Printf("[ERROR] Parse JSON failed, %v", err)
-		}
-		if len(parseStanzaData) == 0 {
-			log.Printf("[WARN] No backup data returned")
-		}
-		for _, singleStanza := range parseStanzaData {
-			getMetrics(singleStanza, verbose, currentUnixTime, setUpMetricValue)
-		}
+
 	}
 }

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -32,6 +32,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 		config            string
 		configIncludePath string
 		stanzas           []string
+		stanzasExclude    []string
 		verbose           bool
 	}
 	tests := []struct {
@@ -42,7 +43,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 		testText   string
 	}{
 		{"GetPgBackRestInfoGoodDataReturn",
-			args{"", "", []string{""}, false},
+			args{"", "", []string{""}, []string{""}, false},
 			`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 				`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
 				`"backup":[{"archive":{"start":"000000010000000000000002","stop":"000000010000000000000002"},` +
@@ -56,20 +57,25 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			0,
 			""},
 		{"GetPgBackRestInfoBadDataReturn",
-			args{"", "", []string{""}, false},
+			args{"", "", []string{""}, []string{""}, false},
 			`Forty two`,
 			1,
 			"[ERROR] pgBackRest error: Forty two"},
 		{"GetPgBackRestInfoZeroDataReturn",
-			args{"", "", []string{""}, false},
+			args{"", "", []string{""}, []string{""}, false},
 			`[]`,
 			0,
 			"[WARN] No backup data returned"},
 		{"GetPgBackRestInfoJsonUnmarshalFail",
-			args{"", "", []string{""}, false},
+			args{"", "", []string{""}, []string{""}, false},
 			`[{}`,
 			0,
 			"[ERROR] Parse JSON failed, unexpected end of JSON input"},
+		{"GetPgBackRestInfoEqualIncludeExcludeLists",
+			args{"", "", []string{"demo"}, []string{"demo"}, false},
+			`[{}`,
+			0,
+			"[WARN] Stanza demo is specified in include and exclude lists"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -84,6 +90,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 				tt.args.config,
 				tt.args.configIncludePath,
 				tt.args.stanzas,
+				tt.args.stanzasExclude,
 				tt.args.verbose,
 			)
 			if !strings.Contains(out.String(), tt.testText) {

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"log"
 	"os/exec"
-	"reflect"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -612,7 +612,7 @@ func compareLastBackups(backups *lastBackupsStruct, currentBackup time.Time, bac
 func stanzaNotInExclude(stanza string, listExclude []string) bool {
 	// Сheck that exclude list is empty.
 	// If so, no excluding stanzas are set during startup.
-	if !reflect.DeepEqual(listExclude, []string{""}) {
+	if strings.Join(listExclude, "") != "" {
 		for _, val := range listExclude {
 			if val == stanza {
 				return false

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -614,7 +614,7 @@ func stanzaNotInExclude(stanza string, listExclude []string) bool {
 	// If so, no excluding stanzas are set during startup.
 	if !reflect.DeepEqual(listExclude, []string{""}) {
 		for _, val := range listExclude {
-			if stanza == val {
+			if val == stanza {
 				return false
 			}
 		}

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os/exec"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -606,4 +607,17 @@ func compareLastBackups(backups *lastBackupsStruct, currentBackup time.Time, bac
 			backups.incr = currentBackup
 		}
 	}
+}
+
+func stanzaNotInExclude(stanza string, listExclude []string) bool {
+	// Сheck that exclude list is empty.
+	// If so, no excluding stanzas are set during startup.
+	if !reflect.DeepEqual(listExclude, []string{""}) {
+		for _, val := range listExclude {
+			if stanza == val {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -492,6 +492,38 @@ func TestCompareLastBackups(t *testing.T) {
 	}
 }
 
+func TestStanzaNotInExclude(t *testing.T) {
+	type args struct {
+		stanza      string
+		listExclude []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"stanzaNotInExcludeEmptyListExclude",
+			args{"", []string{""}},
+			true},
+		{"stanzaNotInExcludeEmptyListExcludeNotEmptyStanza",
+			args{"demo", []string{""}},
+			true},
+		{"stanzaNotInExcludeStanzaNotInExcludeList",
+			args{"demo", []string{"demo-test", "test"}},
+			true},
+		{"stanzaNotInExcludeStanzaInExcludeList",
+			args{"demo", []string{"demo", "test"}},
+			false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stanzaNotInExclude(tt.args.stanza, tt.args.listExclude); got != tt.want {
+				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", got, tt.want)
+			}
+		})
+	}
+}
+
 func fakeSetUpMetricValue(metric *prometheus.GaugeVec, value float64, labels ...string) error {
 	return errors.New("сustorm error for test")
 }

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"reflect"
+	"strings"
 	"syscall"
 	"time"
 
@@ -73,12 +73,12 @@ func main() {
 	if *backrestCustomConfigIncludePath != "" {
 		log.Printf("[INFO] Custom path to additional pgBackRest configuration files %s", *backrestCustomConfigIncludePath)
 	}
-	if !reflect.DeepEqual(*backrestIncludeStanza, []string{""}) {
+	if strings.Join(*backrestIncludeStanza, "") != "" {
 		for _, stanza := range *backrestIncludeStanza {
 			log.Printf("[INFO] Collecting metrics for specific stanza %s", stanza)
 		}
 	}
-	if !reflect.DeepEqual(*backrestExcludeStanza, []string{""}) {
+	if strings.Join(*backrestExcludeStanza, "") != "" {
 		for _, stanza := range *backrestExcludeStanza {
 			log.Printf("[INFO] Exclude collecting metrics for specific stanza %s", stanza)
 		}

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -41,6 +41,10 @@ func main() {
 			"backrest.stanza-include",
 			"Specific stanza for collecting metrics. Can be specified several times.",
 		).Default("").PlaceHolder("\"\"").Strings()
+		backrestExcludeStanza = kingpin.Flag(
+			"backrest.stanza-exclude",
+			"Specific stanza to exclude from collecting metrics. Can be specified several times.",
+		).Default("").PlaceHolder("\"\"").Strings()
 		verboseInfo = kingpin.Flag(
 			"verbose.info",
 			"Enable additional metrics labels.",
@@ -74,6 +78,11 @@ func main() {
 			log.Printf("[INFO] Collecting metrics for specific stanza %s", stanza)
 		}
 	}
+	if !reflect.DeepEqual(*backrestExcludeStanza, []string{""}) {
+		for _, stanza := range *backrestExcludeStanza {
+			log.Printf("[INFO] Exclude collecting metrics for specific stanza %s", stanza)
+		}
+	}
 	// Setup parameters for exporter.
 	backrest.SetPromPortandPath(*promPort, *promPath)
 	log.Printf("[INFO] Use port %s and HTTP endpoint %s", *promPort, *promPath)
@@ -87,6 +96,7 @@ func main() {
 			*backrestCustomConfig,
 			*backrestCustomConfigIncludePath,
 			*backrestIncludeStanza,
+			*backrestExcludeStanza,
 			*verboseInfo,
 		)
 		// Sleep for 'collection.interval' seconds.

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -37,8 +37,8 @@ func main() {
 			"backrest.config-include-path",
 			"Full path to additional pgBackRest configuration files.",
 		).Default("").String()
-		backrestStanza = kingpin.Flag(
-			"backrest.stanza",
+		backrestIncludeStanza = kingpin.Flag(
+			"backrest.stanza-include",
 			"Specific stanza for collecting metrics. Can be specified several times.",
 		).Default("").PlaceHolder("\"\"").Strings()
 		verboseInfo = kingpin.Flag(
@@ -69,8 +69,8 @@ func main() {
 	if *backrestCustomConfigIncludePath != "" {
 		log.Printf("[INFO] Custom path to additional pgBackRest configuration files %s", *backrestCustomConfigIncludePath)
 	}
-	if !reflect.DeepEqual(*backrestStanza, []string{""}) {
-		for _, stanza := range *backrestStanza {
+	if !reflect.DeepEqual(*backrestIncludeStanza, []string{""}) {
+		for _, stanza := range *backrestIncludeStanza {
 			log.Printf("[INFO] Collecting metrics for specific stanza %s", stanza)
 		}
 	}
@@ -86,7 +86,7 @@ func main() {
 		backrest.GetPgBackRestInfo(
 			*backrestCustomConfig,
 			*backrestCustomConfigIncludePath,
-			*backrestStanza,
+			*backrestIncludeStanza,
 			*verboseInfo,
 		)
 		// Sleep for 'collection.interval' seconds.


### PR DESCRIPTION
Added the ability to specify one or multiple stanzas to exclude from collecting metrics:
* flag `backrest.stanza-exclude` - specific stanza to exclude from collecting metrics, by default - "". Can be specified several times;
* flag `backrest.stanza` was renamed to `backrest.stanza-include`.

For Docker image:
* added env variable `STANZA_EXCLUDE`.
* renamed env variable `STANZA` to `STANZA_INCLUDE`.

Updated README.

Refactoring:
* refused to use `reflect.deepEqual` in favor of a simpler check for default values.