### PR TITLE
Rename metrics according to Prometheus naming convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,21 +27,21 @@ The metrics provided by the client.
     Labels: cipher, repo_key, stanza.
 
     Values description for stanza and repo statuses:
-    - 0: ok,
-    - 1: missing stanza path,
-    - 2: no valid backups,
-    - 3: missing stanza data,
-    - 4: different across repos,
-    - 5: database mismatch across repos,
-    - 6: requested backup not found,
-    - 99: other.
+    - `0`: ok,
+    - `1`: missing stanza path,
+    - `2`: no valid backups,
+    - `3`: missing stanza data,
+    - `4`: different across repos,
+    - `5`: database mismatch across repos,
+    - `6`: requested backup not found,
+    - `99`: other.
 
 * `pgbackrest_backup_info` - backup info.
 
     Labels: backrest_ver, backup_name, backup_type, database_id, pg_version, prior, repo_key, stanza, wal_archive_max, wal_archive_min.
 
     Values description:
-     - 1 - info about backup is exist.
+     - `1` - info about backup is exist.
 
 * `pgbackrest_backup_duration_seconds` - backup duration in seconds.
 
@@ -80,8 +80,8 @@ The metrics provided by the client.
     Labels: database_id, pg_version, repo_key, stanza, wal_archive_max, wal_archive_min.
 
     Values description:
-    - 0 - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,
-    - 1 - both WALMin and WALMax have no empty values, there is correct information about WAL archiving.
+    - `0` - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,
+    - `1` - both WALMin and WALMax have no empty values, there is correct information about WAL archiving.
 
 ## Getting Started
 ### Building and running

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ The metrics are collected based on result of `pgbackrest info --output json` com
 All metrics are collected for `pgBackRest >= v2.32`.
 For earlier versions, some metrics may not be collected or have insignificant label values.
 
-For example, the `pgbackrest_exporter_repo_status` metric will be absent for `pgBackRest <= v2.31`.
+For example, the `pgbackrest_repo_status` metric will be absent for `pgBackRest <= v2.31`.
 And for other metrics lable will be `repo_key="0"`.
 
 ## Collected metrics
 
 The metrics provided by the client.
 
-* `pgbackrest_exporter_stanza_status` - current stanza status.
-* `pgbackrest_exporter_repo_status` - current repository status.
+* `pgbackrest_stanza_status` - current stanza status.
+* `pgbackrest_repo_status` - current repository status.
 
     Values description for stanza and repo statuses:
     - 0: ok,
@@ -31,20 +31,20 @@ The metrics provided by the client.
     - 6: requested backup not found,
     - 99: other.
 
-* `pgbackrest_exporter_backup_info` - backup info.
+* `pgbackrest_backup_info` - backup info.
     
     Values description:
      - 1 - info about backup is exist.
 
-* `pgbackrest_exporter_backup_duration` - backup duration in seconds.
-* `pgbackrest_exporter_backup_database_size` - full uncompressed size of the database.
-* `pgbackrest_exporter_backup_database_backup_size` - amount of data in the database to actually backup.
-* `pgbackrest_exporter_backup_repo_backup_set_size` - full compressed files size to restore the database from backup.
-* `pgbackrest_exporter_backup_repo_backup_size` - compressed files size in backup.
-* `pgbackrest_exporter_backup_full_time_since_last_completion` - seconds since the last completed full backup.
-* `pgbackrest_exporter_backup_diff_time_since_last_completion` - seconds since the last completed full or differential backup.
-* `pgbackrest_exporter_backup_incr_time_since_last_completion` - seconds since the last completed full, differential or incremental backup.
-* `pgbackrest_exporter_wal_archive_status` - current WAL archive status.
+* `pgbackrest_backup_duration_seconds` - backup duration in seconds.
+* `pgbackrest_backup_size_bytes` - full uncompressed size of the database.
+* `pgbackrest_backup_delta_bytes` - amount of data in the database to actually backup.
+* `pgbackrest_backup_repo_size_bytes` - full compressed files size to restore the database from backup.
+* `pgbackrest_backup_repo_delta_bytes` - compressed files size in backup.
+* `pgbackrest_backup_full_since_last_completion_seconds` - seconds since the last completed full backup.
+* `pgbackrest_backup_diff_since_last_completion_seconds` - seconds since the last completed full or differential backup.
+* `pgbackrest_backup_incr_since_last_completion_seconds` - seconds since the last completed full, differential or incremental backup.
+* `pgbackrest_wal_archive_status` - current WAL archive status.
 
     Values description:
     - 0 - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ And for other metrics lable will be `repo_key="0"`.
 The metrics provided by the client.
 
 * `pgbackrest_stanza_status` - current stanza status.
+
+    Labels: stanza.
+
 * `pgbackrest_repo_status` - current repository status.
+
+    Labels: cipher, repo_key, stanza.
 
     Values description for stanza and repo statuses:
     - 0: ok,
@@ -32,19 +37,47 @@ The metrics provided by the client.
     - 99: other.
 
 * `pgbackrest_backup_info` - backup info.
-    
+
+    Labels: backrest_ver, backup_name, backup_type, database_id, pg_version, prior, repo_key, stanza, wal_archive_max, wal_archive_min.
+
     Values description:
      - 1 - info about backup is exist.
 
 * `pgbackrest_backup_duration_seconds` - backup duration in seconds.
+
+    Labels: backup_name, backup_type, database_id, repo_key, stanza, start_time, stop_time.
+
 * `pgbackrest_backup_size_bytes` - full uncompressed size of the database.
+
+    Labels: backup_name, backup_type, database_id, repo_key, stanza.
+
 * `pgbackrest_backup_delta_bytes` - amount of data in the database to actually backup.
+
+    Labels: backup_name, backup_type, database_id, repo_key, stanza.
+
 * `pgbackrest_backup_repo_size_bytes` - full compressed files size to restore the database from backup.
+
+    Labels: backup_name, backup_type, database_id, repo_key, stanza.
+
 * `pgbackrest_backup_repo_delta_bytes` - compressed files size in backup.
+
+    Labels: backup_name, backup_type, database_id, repo_key, stanza.
+
 * `pgbackrest_backup_full_since_last_completion_seconds` - seconds since the last completed full backup.
+
+    Labels: stanza.
+
 * `pgbackrest_backup_diff_since_last_completion_seconds` - seconds since the last completed full or differential backup.
+
+    Labels: stanza.
+
 * `pgbackrest_backup_incr_since_last_completion_seconds` - seconds since the last completed full, differential or incremental backup.
+
+    Labels: stanza.
+
 * `pgbackrest_wal_archive_status` - current WAL archive status.
+
+    Labels: database_id, pg_version, repo_key, stanza, wal_archive_max, wal_archive_min.
 
     Values description:
     - 0 - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The metrics provided by the client.
 
 * `pgbackrest_backup_info` - backup info.
 
-    Labels: backrest_ver, backup_name, backup_type, database_id, pg_version, prior, repo_key, stanza, wal_archive_max, wal_archive_min.
+    Labels: backrest_ver, backup_name, backup_type, database_id, pg_version, prior, repo_key, stanza, wal_start, wal_stop.
 
     Values description:
      - `1` - info about backup is exist.
@@ -77,7 +77,7 @@ The metrics provided by the client.
 
 * `pgbackrest_wal_archive_status` - current WAL archive status.
 
-    Labels: database_id, pg_version, repo_key, stanza, wal_archive_max, wal_archive_min.
+    Labels: database_id, pg_version, repo_key, stanza, wal_max, wal_min.
 
     Values description:
     - `0` - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -23,12 +23,12 @@ type lastBackupsStruct struct {
 
 var (
 	pgbrStanzaStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_stanza_status",
+		Name: "pgbackrest_stanza_status",
 		Help: "Current stanza status.",
 	},
 		[]string{"stanza"})
 	pgbrRepoStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_repo_status",
+		Name: "pgbackrest_repo_status",
 		Help: "Current repository status.",
 	},
 		[]string{
@@ -37,7 +37,7 @@ var (
 			"stanza",
 		})
 	pgbrStanzaBackupInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_info",
+		Name: "pgbackrest_backup_info",
 		Help: "Backup info.",
 	},
 		[]string{
@@ -52,8 +52,8 @@ var (
 			"wal_archive_min",
 			"wal_archive_max"})
 	pgbrStanzaBackupDurationMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_duration",
-		Help: "Backup duration in seconds.",
+		Name: "pgbackrest_backup_duration_seconds",
+		Help: "Backup duration.",
 	},
 		[]string{
 			"backup_name",
@@ -63,9 +63,11 @@ var (
 			"stanza",
 			"start_time",
 			"stop_time"})
-	// The 'database size' is the full uncompressed size of the database.
+	// The 'database size' for text pgBackRest output
+	// (or "backup":"info":"size" for json pgBackRest output)
+	// is the full uncompressed size of the database.
 	pgbrStanzaBackupDatabaseSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_database_size",
+		Name: "pgbackrest_backup_size_bytes",
 		Help: "Full uncompressed size of the database.",
 	},
 		[]string{
@@ -74,10 +76,12 @@ var (
 			"database_id",
 			"repo_key",
 			"stanza"})
-	// The 'database backup size' is the amount of data in the database
+	// The 'database backup size' for text pgBackRest output
+	// (or "backup":"info":"delta" for json pgBackRest output)
+	// is the amount of data in the database
 	// to actually backup (these will be the same for full backups).
 	pgbrStanzaBackupDatabaseBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_database_backup_size",
+		Name: "pgbackrest_backup_delta_bytes",
 		Help: "Amount of data in the database to actually backup.",
 	},
 		[]string{
@@ -86,13 +90,15 @@ var (
 			"database_id",
 			"repo_key",
 			"stanza"})
-	// The 'backup set size' includes all the files from this backup and
+	// The 'backup set size' for text pgBackRest output
+	// (or "backup":"info":"repository":"size" for json pgBackRest output)
+	// includes all the files from this backup and
 	// any referenced backups in the repository that are required
 	// to restore the database from this backup.
 	// Repository 'backup set size' reflect compressed file sizes
 	// if compression is enabled in pgBackRest or the filesystem.
 	pgbrStanzaBackupRepoBackupSetSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_repo_backup_set_size",
+		Name: "pgbackrest_backup_repo_size_bytes",
 		Help: "Full compressed files size to restore the database from backup.",
 	},
 		[]string{
@@ -101,12 +107,14 @@ var (
 			"database_id",
 			"repo_key",
 			"stanza"})
-	// The 'backup size' includes only the files in this backup
+	// The 'backup size' for text pgBackRest output
+	// (or "backup":"info":"repository":"delta" for json pgBackRest output)
+	// includes only the files in this backup
 	// (these will also be the same for full backups).
 	// Repository 'backup size' reflect compressed file sizes
 	// if compression is enabled in pgBackRest or the filesystem.
 	pgbrStanzaBackupRepoBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_repo_backup_size",
+		Name: "pgbackrest_backup_repo_delta_bytes",
 		Help: "Compressed files size in backup.",
 	},
 		[]string{
@@ -116,14 +124,14 @@ var (
 			"repo_key",
 			"stanza"})
 	pgbrStanzaBackupLastFullMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_full_time_since_last_completion",
+		Name: "pgbackrest_backup_full_since_last_completion_seconds",
 		Help: "Seconds since the last completed full backup.",
 	},
 		[]string{"stanza"})
 	// Differential backup is always based on last full,
 	// if the last backup was full, the metric will take full backup value.
 	pgbrStanzaBackupLastDiffMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_diff_time_since_last_completion",
+		Name: "pgbackrest_backup_diff_since_last_completion_seconds",
 		Help: "Seconds since the last completed full or differential backup.",
 	},
 		[]string{"stanza"})
@@ -131,12 +139,12 @@ var (
 	// if the last backup was full or differential, the metric will take
 	// full or differential backup value.
 	pgbrStanzaBackupLastIncrMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_backup_incr_time_since_last_completion",
+		Name: "pgbackrest_backup_incr_since_last_completion_seconds",
 		Help: "Seconds since the last completed full, differential or incremental backup.",
 	},
 		[]string{"stanza"})
 	pgbrWALArchivingMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_exporter_wal_archive_status",
+		Name: "pgbackrest_wal_archive_status",
 		Help: "Current WAL archive status.",
 	},
 		[]string{
@@ -251,7 +259,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 	)
 	if err != nil {
 		log.Println(
-			"[ERROR] Metric pgbackrest_exporter_stanza_status set up failed;",
+			"[ERROR] Metric pgbackrest_stanza_status set up failed;",
 			"value:", float64(data.Status.Code), ";",
 			"labels:",
 			data.Name,
@@ -268,7 +276,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_repo_status set up failed;",
+				"[ERROR] Metric pgbackrest_repo_status set up failed;",
 				"value:", float64(repo.Status.Code), ";",
 				"labels:",
 				repo.Cipher, ",",
@@ -296,7 +304,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_info set up failed;",
+				"[ERROR] Metric pgbackrest_backup_info set up failed;",
 				"value:", 1, ";",
 				"labels:",
 				backup.BackrestInfo.Version, ",",
@@ -325,7 +333,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_duration set up failed;",
+				"[ERROR] Metric pgbackrest_backup_duration_seconds set up failed;",
 				"value:",
 				time.Unix(backup.Timestamp.Stop, 0).Sub(time.Unix(backup.Timestamp.Start, 0)).Seconds(),
 				";",
@@ -351,7 +359,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_database_size set up failed;",
+				"[ERROR] Metric pgbackrest_backup_size_bytes set up failed;",
 				"value:", float64(backup.Info.Size), ";",
 				"labels:",
 				backup.Label, ",",
@@ -373,7 +381,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_database_backup_size set up failed;",
+				"[ERROR] Metric pgbackrest_backup_delta_bytes set up failed;",
 				"value:", float64(backup.Info.Delta), ";",
 				"labels:",
 				backup.Label, ",",
@@ -395,7 +403,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_repo_backup_set_size set up failed;",
+				"[ERROR] Metric pgbackrest_backup_repo_size_bytes set up failed;",
 				"value:", float64(backup.Info.Repository.Size), ";",
 				"labels:",
 				backup.Label, ",",
@@ -417,7 +425,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_repo_backup_size set up failed;",
+				"[ERROR] Metric pgbackrest_backup_repo_delta_bytes set up failed;",
 				"value:", float64(backup.Info.Repository.Delta), ";",
 				"labels:",
 				backup.Label, ",",
@@ -446,7 +454,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_full_time_since_last_completion set up failed;",
+				"[ERROR] Metric pgbackrest_backup_full_since_last_completion_seconds set up failed;",
 				"value:", time.Unix(currentUnixTime, 0).Sub(lastBackups.full).Seconds(), ";",
 				"labels:",
 				data.Name,
@@ -460,7 +468,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_diff_time_since_last_completion set up failed;",
+				"[ERROR] Metric pgbackrest_backup_diff_since_last_completion_seconds set up failed;",
 				"value:", time.Unix(currentUnixTime, 0).Sub(lastBackups.diff).Seconds(), ";",
 				"labels:",
 				data.Name,
@@ -474,7 +482,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 		)
 		if err != nil {
 			log.Println(
-				"[ERROR] Metric pgbackrest_exporter_backup_incr_time_since_last_completion set up failed;",
+				"[ERROR] Metric pgbackrest_backup_incr_since_last_completion_seconds set up failed;",
 				"value:", time.Unix(currentUnixTime, 0).Sub(lastBackups.incr).Seconds(), ";",
 				"labels:",
 				data.Name,
@@ -502,7 +510,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 				)
 				if err != nil {
 					log.Println(
-						"[ERROR] Metric pgbackrest_exporter_wal_archive_status set up failed;",
+						"[ERROR] Metric pgbackrest_wal_archive_status set up failed;",
 						"value:", 1, ";",
 						"labels:",
 						strconv.Itoa(archive.Database.ID), ",",
@@ -526,7 +534,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 				)
 				if err != nil {
 					log.Println(
-						"[ERROR] Metric pgbackrest_exporter_wal_archive_status set up failed;",
+						"[ERROR] Metric pgbackrest_wal_archive_status set up failed;",
 						"value:", 1, ";",
 						"labels:",
 						strconv.Itoa(archive.Database.ID), ",",
@@ -551,7 +559,7 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 			)
 			if err != nil {
 				log.Println(
-					"[ERROR] Metric pgbackrest_exporter_wal_archive_status set up failed;",
+					"[ERROR] Metric pgbackrest_wal_archive_status set up failed;",
 					"value:", 0, ";",
 					"labels:",
 					strconv.Itoa(archive.Database.ID), ",",

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -46,11 +46,11 @@ var (
 			"backup_type",
 			"database_id",
 			"pg_version",
+			"prior",
 			"repo_key",
 			"stanza",
-			"prior",
-			"wal_archive_min",
-			"wal_archive_max"})
+			"wal_archive_max",
+			"wal_archive_min"})
 	pgbrStanzaBackupDurationMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pgbackrest_backup_duration_seconds",
 		Help: "Backup duration.",
@@ -152,8 +152,8 @@ var (
 			"pg_version",
 			"repo_key",
 			"stanza",
-			"wal_archive_min",
-			"wal_archive_max"})
+			"wal_archive_max",
+			"wal_archive_min"})
 	execCommand = exec.Command
 )
 
@@ -296,11 +296,11 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 			backup.Type,
 			strconv.Itoa(backup.Database.ID),
 			getPGVersion(backup.Database.ID, backup.Database.RepoKey, data.DB),
+			backup.Prior,
 			strconv.Itoa(backup.Database.RepoKey),
 			data.Name,
-			backup.Prior,
-			backup.Archive.StartWAL,
 			backup.Archive.StopWAL,
+			backup.Archive.StartWAL,
 		)
 		if err != nil {
 			log.Println(
@@ -312,11 +312,11 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 				backup.Type, ",",
 				strconv.Itoa(backup.Database.ID), ",",
 				getPGVersion(backup.Database.ID, backup.Database.RepoKey, data.DB), ",",
+				backup.Prior, ",",
 				strconv.Itoa(backup.Database.RepoKey), ",",
 				data.Name, ",",
-				backup.Prior, ",",
-				backup.Archive.StartWAL, ",",
-				backup.Archive.StopWAL,
+				backup.Archive.StopWAL, ",",
+				backup.Archive.StartWAL,
 			)
 		}
 		// Backup durations in seconds.
@@ -505,8 +505,8 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 					getPGVersion(archive.Database.ID, archive.Database.RepoKey, data.DB),
 					strconv.Itoa(archive.Database.RepoKey),
 					data.Name,
-					archive.WALMin,
 					archive.WALMax,
+					archive.WALMin,
 				)
 				if err != nil {
 					log.Println(
@@ -517,8 +517,8 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 						getPGVersion(archive.Database.ID, archive.Database.RepoKey, data.DB), ",",
 						strconv.Itoa(archive.Database.RepoKey), ",",
 						data.Name, ",",
-						archive.WALMin, ",",
-						archive.WALMax,
+						archive.WALMax, ",",
+						archive.WALMin,
 					)
 				}
 			} else {

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -49,8 +49,8 @@ var (
 			"prior",
 			"repo_key",
 			"stanza",
-			"wal_archive_max",
-			"wal_archive_min"})
+			"wal_start",
+			"wal_stop"})
 	pgbrStanzaBackupDurationMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pgbackrest_backup_duration_seconds",
 		Help: "Backup duration.",
@@ -152,8 +152,8 @@ var (
 			"pg_version",
 			"repo_key",
 			"stanza",
-			"wal_archive_max",
-			"wal_archive_min"})
+			"wal_max",
+			"wal_min"})
 	execCommand = exec.Command
 )
 
@@ -299,8 +299,8 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 			backup.Prior,
 			strconv.Itoa(backup.Database.RepoKey),
 			data.Name,
-			backup.Archive.StopWAL,
 			backup.Archive.StartWAL,
+			backup.Archive.StopWAL,
 		)
 		if err != nil {
 			log.Println(
@@ -315,8 +315,8 @@ func getMetrics(data stanza, verbose bool, currentUnixTime int64, setUpMetricVal
 				backup.Prior, ",",
 				strconv.Itoa(backup.Database.RepoKey), ",",
 				data.Name, ",",
-				backup.Archive.StopWAL, ",",
-				backup.Archive.StartWAL,
+				backup.Archive.StartWAL, ",",
+				backup.Archive.StopWAL,
 			)
 		}
 		// Backup durations in seconds.

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -40,7 +40,7 @@ pgbackrest_backup_full_since_last_completion_seconds{stanza="demo"} 9.2233720368
 pgbackrest_backup_incr_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
-pgbackrest_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="1",stanza="demo",wal_archive_max="000000010000000000000002",wal_archive_min="000000010000000000000002"} 1
+pgbackrest_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
 # HELP pgbackrest_backup_repo_delta_bytes Compressed files size in backup.
 # TYPE pgbackrest_backup_repo_delta_bytes gauge
 pgbackrest_backup_repo_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
@@ -68,7 +68,7 @@ pgbackrest_stanza_status{stanza="demo"} 0
 				templateStanza("000000010000000000000004", "000000010000000000000001"),
 				false,
 				templateMetrics +
-					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="",wal_archive_min=""} 1` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_max="",wal_min=""} 1` +
 					"\n",
 				setUpMetricValue,
 			},
@@ -78,7 +78,7 @@ pgbackrest_stanza_status{stanza="demo"} 0
 				templateStanza("000000010000000000000004", "000000010000000000000001"),
 				true,
 				templateMetrics +
-					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="000000010000000000000004",wal_archive_min="000000010000000000000001"} 1` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_max="000000010000000000000004",wal_min="000000010000000000000001"} 1` +
 					"\n",
 				setUpMetricValue,
 			},
@@ -88,7 +88,7 @@ pgbackrest_stanza_status{stanza="demo"} 0
 				templateStanza("", "000000010000000000000001"),
 				false,
 				templateMetrics +
-					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="",wal_archive_min=""} 0` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_max="",wal_min=""} 0` +
 					"\n",
 				setUpMetricValue,
 			},
@@ -154,7 +154,7 @@ pgbackrest_backup_full_since_last_completion_seconds{stanza="demo"} 9.2233720368
 pgbackrest_backup_incr_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
-pgbackrest_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="0",stanza="demo",wal_archive_max="000000010000000000000002",wal_archive_min="000000010000000000000002"} 1
+pgbackrest_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="0",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
 # HELP pgbackrest_backup_repo_delta_bytes Compressed files size in backup.
 # TYPE pgbackrest_backup_repo_delta_bytes gauge
 pgbackrest_backup_repo_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.969514e+06
@@ -179,7 +179,7 @@ pgbackrest_stanza_status{stanza="demo"} 0
 				templateStanzaRepoAbsent("000000010000000000000004", "000000010000000000000001"),
 				false,
 				templateMetrics +
-					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="0",stanza="demo",wal_archive_max="",wal_archive_min=""} 1` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="0",stanza="demo",wal_max="",wal_min=""} 1` +
 					"\n",
 				setUpMetricValue,
 			},

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -23,41 +23,41 @@ func TestGetMetrics(t *testing.T) {
 		testText            string
 		setUpMetricValueFun setUpMetricValueFunType
 	}
-	templateMetrics := `# HELP pgbackrest_exporter_backup_database_backup_size Amount of data in the database to actually backup.
-# TYPE pgbackrest_exporter_backup_database_backup_size gauge
-pgbackrest_exporter_backup_database_backup_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
-# HELP pgbackrest_exporter_backup_database_size Full uncompressed size of the database.
-# TYPE pgbackrest_exporter_backup_database_size gauge
-pgbackrest_exporter_backup_database_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
-# HELP pgbackrest_exporter_backup_diff_time_since_last_completion Seconds since the last completed full or differential backup.
-# TYPE pgbackrest_exporter_backup_diff_time_since_last_completion gauge
-pgbackrest_exporter_backup_diff_time_since_last_completion{stanza="demo"} 9.223372036854776e+09
-# HELP pgbackrest_exporter_backup_duration Backup duration in seconds.
-# TYPE pgbackrest_exporter_backup_duration gauge
-pgbackrest_exporter_backup_duration{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo",start_time="2021-06-07 12:24:23",stop_time="2021-06-07 12:24:26"} 3
-# HELP pgbackrest_exporter_backup_full_time_since_last_completion Seconds since the last completed full backup.
-# TYPE pgbackrest_exporter_backup_full_time_since_last_completion gauge
-pgbackrest_exporter_backup_full_time_since_last_completion{stanza="demo"} 9.223372036854776e+09
-# HELP pgbackrest_exporter_backup_incr_time_since_last_completion Seconds since the last completed full, differential or incremental backup.
-# TYPE pgbackrest_exporter_backup_incr_time_since_last_completion gauge
-pgbackrest_exporter_backup_incr_time_since_last_completion{stanza="demo"} 9.223372036854776e+09
-# HELP pgbackrest_exporter_backup_info Backup info.
-# TYPE pgbackrest_exporter_backup_info gauge
-pgbackrest_exporter_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="1",stanza="demo",wal_archive_max="000000010000000000000002",wal_archive_min="000000010000000000000002"} 1
-# HELP pgbackrest_exporter_backup_repo_backup_set_size Full compressed files size to restore the database from backup.
-# TYPE pgbackrest_exporter_backup_repo_backup_set_size gauge
-pgbackrest_exporter_backup_repo_backup_set_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
-# HELP pgbackrest_exporter_backup_repo_backup_size Compressed files size in backup.
-# TYPE pgbackrest_exporter_backup_repo_backup_size gauge
-pgbackrest_exporter_backup_repo_backup_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
-# HELP pgbackrest_exporter_repo_status Current repository status.
-# TYPE pgbackrest_exporter_repo_status gauge
-pgbackrest_exporter_repo_status{cipher="none",repo_key="1",stanza="demo"} 0
-# HELP pgbackrest_exporter_stanza_status Current stanza status.
-# TYPE pgbackrest_exporter_stanza_status gauge
-pgbackrest_exporter_stanza_status{stanza="demo"} 0
-# HELP pgbackrest_exporter_wal_archive_status Current WAL archive status.
-# TYPE pgbackrest_exporter_wal_archive_status gauge
+	templateMetrics := `# HELP pgbackrest_backup_delta_bytes Amount of data in the database to actually backup.
+# TYPE pgbackrest_backup_delta_bytes gauge
+pgbackrest_backup_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
+# HELP pgbackrest_backup_diff_since_last_completion_seconds Seconds since the last completed full or differential backup.
+# TYPE pgbackrest_backup_diff_since_last_completion_seconds gauge
+pgbackrest_backup_diff_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
+# HELP pgbackrest_backup_duration_seconds Backup duration.
+# TYPE pgbackrest_backup_duration_seconds gauge
+pgbackrest_backup_duration_seconds{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo",start_time="2021-06-07 12:24:23",stop_time="2021-06-07 12:24:26"} 3
+# HELP pgbackrest_backup_full_since_last_completion_seconds Seconds since the last completed full backup.
+# TYPE pgbackrest_backup_full_since_last_completion_seconds gauge
+pgbackrest_backup_full_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
+# HELP pgbackrest_backup_incr_since_last_completion_seconds Seconds since the last completed full, differential or incremental backup.
+# TYPE pgbackrest_backup_incr_since_last_completion_seconds gauge
+pgbackrest_backup_incr_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
+# HELP pgbackrest_backup_info Backup info.
+# TYPE pgbackrest_backup_info gauge
+pgbackrest_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="1",stanza="demo",wal_archive_max="000000010000000000000002",wal_archive_min="000000010000000000000002"} 1
+# HELP pgbackrest_backup_repo_delta_bytes Compressed files size in backup.
+# TYPE pgbackrest_backup_repo_delta_bytes gauge
+pgbackrest_backup_repo_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
+# HELP pgbackrest_backup_repo_size_bytes Full compressed files size to restore the database from backup.
+# TYPE pgbackrest_backup_repo_size_bytes gauge
+pgbackrest_backup_repo_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
+# HELP pgbackrest_backup_size_bytes Full uncompressed size of the database.
+# TYPE pgbackrest_backup_size_bytes gauge
+pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
+# HELP pgbackrest_repo_status Current repository status.
+# TYPE pgbackrest_repo_status gauge
+pgbackrest_repo_status{cipher="none",repo_key="1",stanza="demo"} 0
+# HELP pgbackrest_stanza_status Current stanza status.
+# TYPE pgbackrest_stanza_status gauge
+pgbackrest_stanza_status{stanza="demo"} 0
+# HELP pgbackrest_wal_archive_status Current WAL archive status.
+# TYPE pgbackrest_wal_archive_status gauge
 `
 	tests := []struct {
 		name string
@@ -68,7 +68,7 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 				templateStanza("000000010000000000000004", "000000010000000000000001"),
 				false,
 				templateMetrics +
-					`pgbackrest_exporter_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="",wal_archive_min=""} 1` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="",wal_archive_min=""} 1` +
 					"\n",
 				setUpMetricValue,
 			},
@@ -78,7 +78,7 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 				templateStanza("000000010000000000000004", "000000010000000000000001"),
 				true,
 				templateMetrics +
-					`pgbackrest_exporter_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="000000010000000000000004",wal_archive_min="000000010000000000000001"} 1` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="000000010000000000000004",wal_archive_min="000000010000000000000001"} 1` +
 					"\n",
 				setUpMetricValue,
 			},
@@ -88,7 +88,7 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 				templateStanza("", "000000010000000000000001"),
 				false,
 				templateMetrics +
-					`pgbackrest_exporter_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="",wal_archive_min=""} 0` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="1",stanza="demo",wal_archive_max="",wal_archive_min=""} 0` +
 					"\n",
 				setUpMetricValue,
 			},
@@ -137,38 +137,38 @@ func TestGetMetricsRepoAbsent(t *testing.T) {
 		testText            string
 		setUpMetricValueFun setUpMetricValueFunType
 	}
-	templateMetrics := `# HELP pgbackrest_exporter_backup_database_backup_size Amount of data in the database to actually backup.
-# TYPE pgbackrest_exporter_backup_database_backup_size gauge
-pgbackrest_exporter_backup_database_backup_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.4316343e+07
-# HELP pgbackrest_exporter_backup_database_size Full uncompressed size of the database.
-# TYPE pgbackrest_exporter_backup_database_size gauge
-pgbackrest_exporter_backup_database_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.4316343e+07
-# HELP pgbackrest_exporter_backup_diff_time_since_last_completion Seconds since the last completed full or differential backup.
-# TYPE pgbackrest_exporter_backup_diff_time_since_last_completion gauge
-pgbackrest_exporter_backup_diff_time_since_last_completion{stanza="demo"} 9.223372036854776e+09
-# HELP pgbackrest_exporter_backup_duration Backup duration in seconds.
-# TYPE pgbackrest_exporter_backup_duration gauge
-pgbackrest_exporter_backup_duration{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo",start_time="2021-06-07 12:24:23",stop_time="2021-06-07 12:24:26"} 3
-# HELP pgbackrest_exporter_backup_full_time_since_last_completion Seconds since the last completed full backup.
-# TYPE pgbackrest_exporter_backup_full_time_since_last_completion gauge
-pgbackrest_exporter_backup_full_time_since_last_completion{stanza="demo"} 9.223372036854776e+09
-# HELP pgbackrest_exporter_backup_incr_time_since_last_completion Seconds since the last completed full, differential or incremental backup.
-# TYPE pgbackrest_exporter_backup_incr_time_since_last_completion gauge
-pgbackrest_exporter_backup_incr_time_since_last_completion{stanza="demo"} 9.223372036854776e+09
-# HELP pgbackrest_exporter_backup_info Backup info.
-# TYPE pgbackrest_exporter_backup_info gauge
-pgbackrest_exporter_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="0",stanza="demo",wal_archive_max="000000010000000000000002",wal_archive_min="000000010000000000000002"} 1
-# HELP pgbackrest_exporter_backup_repo_backup_set_size Full compressed files size to restore the database from backup.
-# TYPE pgbackrest_exporter_backup_repo_backup_set_size gauge
-pgbackrest_exporter_backup_repo_backup_set_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.969514e+06
-# HELP pgbackrest_exporter_backup_repo_backup_size Compressed files size in backup.
-# TYPE pgbackrest_exporter_backup_repo_backup_size gauge
-pgbackrest_exporter_backup_repo_backup_size{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.969514e+06
-# HELP pgbackrest_exporter_stanza_status Current stanza status.
-# TYPE pgbackrest_exporter_stanza_status gauge
-pgbackrest_exporter_stanza_status{stanza="demo"} 0
-# HELP pgbackrest_exporter_wal_archive_status Current WAL archive status.
-# TYPE pgbackrest_exporter_wal_archive_status gauge
+	templateMetrics := `# HELP pgbackrest_backup_delta_bytes Amount of data in the database to actually backup.
+# TYPE pgbackrest_backup_delta_bytes gauge
+pgbackrest_backup_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.4316343e+07
+# HELP pgbackrest_backup_diff_since_last_completion_seconds Seconds since the last completed full or differential backup.
+# TYPE pgbackrest_backup_diff_since_last_completion_seconds gauge
+pgbackrest_backup_diff_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
+# HELP pgbackrest_backup_duration_seconds Backup duration.
+# TYPE pgbackrest_backup_duration_seconds gauge
+pgbackrest_backup_duration_seconds{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo",start_time="2021-06-07 12:24:23",stop_time="2021-06-07 12:24:26"} 3
+# HELP pgbackrest_backup_full_since_last_completion_seconds Seconds since the last completed full backup.
+# TYPE pgbackrest_backup_full_since_last_completion_seconds gauge
+pgbackrest_backup_full_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
+# HELP pgbackrest_backup_incr_since_last_completion_seconds Seconds since the last completed full, differential or incremental backup.
+# TYPE pgbackrest_backup_incr_since_last_completion_seconds gauge
+pgbackrest_backup_incr_since_last_completion_seconds{stanza="demo"} 9.223372036854776e+09
+# HELP pgbackrest_backup_info Backup info.
+# TYPE pgbackrest_backup_info gauge
+pgbackrest_backup_info{backrest_ver="2.34",backup_name="20210607-092423F",backup_type="full",database_id="1",pg_version="13",prior="",repo_key="0",stanza="demo",wal_archive_max="000000010000000000000002",wal_archive_min="000000010000000000000002"} 1
+# HELP pgbackrest_backup_repo_delta_bytes Compressed files size in backup.
+# TYPE pgbackrest_backup_repo_delta_bytes gauge
+pgbackrest_backup_repo_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.969514e+06
+# HELP pgbackrest_backup_repo_size_bytes Full compressed files size to restore the database from backup.
+# TYPE pgbackrest_backup_repo_size_bytes gauge
+pgbackrest_backup_repo_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.969514e+06
+# HELP pgbackrest_backup_size_bytes Full uncompressed size of the database.
+# TYPE pgbackrest_backup_size_bytes gauge
+pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.4316343e+07
+# HELP pgbackrest_stanza_status Current stanza status.
+# TYPE pgbackrest_stanza_status gauge
+pgbackrest_stanza_status{stanza="demo"} 0
+# HELP pgbackrest_wal_archive_status Current WAL archive status.
+# TYPE pgbackrest_wal_archive_status gauge
 `
 	tests := []struct {
 		name string
@@ -179,7 +179,7 @@ pgbackrest_exporter_stanza_status{stanza="demo"} 0
 				templateStanzaRepoAbsent("000000010000000000000004", "000000010000000000000001"),
 				false,
 				templateMetrics +
-					`pgbackrest_exporter_wal_archive_status{database_id="1",pg_version="13",repo_key="0",stanza="demo",wal_archive_max="",wal_archive_min=""} 1` +
+					`pgbackrest_wal_archive_status{database_id="1",pg_version="13",repo_key="0",stanza="demo",wal_archive_max="",wal_archive_min=""} 1` +
 					"\n",
 				setUpMetricValue,
 			},


### PR DESCRIPTION
Resolves #9 .

List of renamed metrics.

| Old name | New name |
| --- | --- |
|pgbackrest_exporter_stanza_status|pgbackrest_stanza_status|
|pgbackrest_exporter_repo_status|pgbackrest_repo_status|
|pgbackrest_exporter_backup_info|pgbackrest_backup_info|
|pgbackrest_exporter_backup_duration|pgbackrest_backup_duration_seconds|
|pgbackrest_exporter_backup_database_size|pgbackrest_backup_size_bytes|
|pgbackrest_exporter_backup_database_backup_size|pgbackrest_backup_delta_bytes|
|pgbackrest_exporter_backup_repo_backup_set_size|pgbackrest_backup_repo_size_bytes|
|pgbackrest_exporter_backup_repo_backup_size|pgbackrest_backup_repo_delta_bytes|
|pgbackrest_exporter_backup_full_time_since_last_completion|pgbackrest_backup_full_since_last_completion_seconds|
|pgbackrest_exporter_backup_diff_time_since_last_completion|pgbackrest_backup_diff_since_last_completion_seconds|
|pgbackrest_exporter_backup_incr_time_since_last_completion|pgbackrest_backup_incr_since_last_completion_seconds|
|pgbackrest_exporter_wal_archive_status|pgbackrest_wal_archive_status|

List of renamed labels.

|Metric name | Old name | New name |
| --- | --- | --- |
|pgbackrest_backup_info|wal_archive_min|wal_start|
|pgbackrest_backup_info|wal_archive_max|wal_stop|
|pgbackrest_wal_archive_status|wal_archive_min|wal_min|
|pgbackrest_wal_archive_status|wal_archive_max|wal_max|

Refactoring:
* labels for each metric are sorted alphabetically in the source code.
