### PR TITLE
Add exporter info metric.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,12 @@ build:
 	@make test
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -trimpath -ldflags "-X main.version=$(BRANCH)-$(GIT_REV)" -o $(APP_NAME) $(APP_NAME).go
 
+.PHONY: build-arm
+build-arm:
+	@echo "Build $(APP_NAME)"
+	@make test
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -mod=vendor -trimpath -ldflags "-X main.version=$(BRANCH)-$(GIT_REV)" -o $(APP_NAME) $(APP_NAME).go
+
 .PHONY: build-darwin
 build-darwin:
 	@echo "Build $(APP_NAME)"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The metrics provided by the client.
     - `0` - any one of WALMin and WALMax have empty value, there is no correct information about WAL archiving,
     - `1` - both WALMin and WALMax have no empty values, there is correct information about WAL archiving.
 
+* `pgbackrest_exporter_info` - information about pgBackRest exporter.
+
+    Labels: version.
+
 ## Getting Started
 ### Building and running
 

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -5,12 +5,151 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var (
-	promPort     string
-	promEndpoint string
+	promPort               string
+	promEndpoint           string
+	pgbrStanzaStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_stanza_status",
+		Help: "Current stanza status.",
+	},
+		[]string{"stanza"})
+	pgbrRepoStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_repo_status",
+		Help: "Current repository status.",
+	},
+		[]string{
+			"cipher",
+			"repo_key",
+			"stanza",
+		})
+	pgbrStanzaBackupInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_info",
+		Help: "Backup info.",
+	},
+		[]string{
+			"backrest_ver",
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"pg_version",
+			"prior",
+			"repo_key",
+			"stanza",
+			"wal_start",
+			"wal_stop"})
+	pgbrStanzaBackupDurationMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_duration_seconds",
+		Help: "Backup duration.",
+	},
+		[]string{
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"repo_key",
+			"stanza",
+			"start_time",
+			"stop_time"})
+	// The 'database size' for text pgBackRest output
+	// (or "backup":"info":"size" for json pgBackRest output)
+	// is the full uncompressed size of the database.
+	pgbrStanzaBackupDatabaseSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_size_bytes",
+		Help: "Full uncompressed size of the database.",
+	},
+		[]string{
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"repo_key",
+			"stanza"})
+	// The 'database backup size' for text pgBackRest output
+	// (or "backup":"info":"delta" for json pgBackRest output)
+	// is the amount of data in the database
+	// to actually backup (these will be the same for full backups).
+	pgbrStanzaBackupDatabaseBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_delta_bytes",
+		Help: "Amount of data in the database to actually backup.",
+	},
+		[]string{
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"repo_key",
+			"stanza"})
+	// The 'backup set size' for text pgBackRest output
+	// (or "backup":"info":"repository":"size" for json pgBackRest output)
+	// includes all the files from this backup and
+	// any referenced backups in the repository that are required
+	// to restore the database from this backup.
+	// Repository 'backup set size' reflect compressed file sizes
+	// if compression is enabled in pgBackRest or the filesystem.
+	pgbrStanzaBackupRepoBackupSetSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_repo_size_bytes",
+		Help: "Full compressed files size to restore the database from backup.",
+	},
+		[]string{
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"repo_key",
+			"stanza"})
+	// The 'backup size' for text pgBackRest output
+	// (or "backup":"info":"repository":"delta" for json pgBackRest output)
+	// includes only the files in this backup
+	// (these will also be the same for full backups).
+	// Repository 'backup size' reflect compressed file sizes
+	// if compression is enabled in pgBackRest or the filesystem.
+	pgbrStanzaBackupRepoBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_repo_delta_bytes",
+		Help: "Compressed files size in backup.",
+	},
+		[]string{
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"repo_key",
+			"stanza"})
+	pgbrStanzaBackupLastFullMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_full_since_last_completion_seconds",
+		Help: "Seconds since the last completed full backup.",
+	},
+		[]string{"stanza"})
+	// Differential backup is always based on last full,
+	// if the last backup was full, the metric will take full backup value.
+	pgbrStanzaBackupLastDiffMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_diff_since_last_completion_seconds",
+		Help: "Seconds since the last completed full or differential backup.",
+	},
+		[]string{"stanza"})
+	// Incremental backup is always based on last full or differential,
+	// if the last backup was full or differential, the metric will take
+	// full or differential backup value.
+	pgbrStanzaBackupLastIncrMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_incr_since_last_completion_seconds",
+		Help: "Seconds since the last completed full, differential or incremental backup.",
+	},
+		[]string{"stanza"})
+	pgbrWALArchivingMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_wal_archive_status",
+		Help: "Current WAL archive status.",
+	},
+		[]string{
+			"database_id",
+			"pg_version",
+			"repo_key",
+			"stanza",
+			"wal_max",
+			"wal_min"})
+	pgbrExporterInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_exporter_info",
+		Help: "Information about pgBackRest exporter.",
+	},
+		[]string{"version"})
 )
 
 // SetPromPortandPath sets HTTP endpoint parameters from command line arguments 'port' and 'endpoint'
@@ -85,4 +224,9 @@ func GetPgBackRestInfo(config, configIncludePath string, stanzas []string, stanz
 		}
 
 	}
+}
+
+// GetExporterInfo set exporter info metric
+func GetExporterInfo(exporterVersion string) {
+	getExporterMetrics(exporterVersion, setUpMetricValue)
 }

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 type setUpMetricValueFunType func(metric *prometheus.GaugeVec, value float64, labels ...string) error
@@ -22,141 +21,7 @@ type lastBackupsStruct struct {
 	incr time.Time
 }
 
-var (
-	pgbrStanzaStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_stanza_status",
-		Help: "Current stanza status.",
-	},
-		[]string{"stanza"})
-	pgbrRepoStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_repo_status",
-		Help: "Current repository status.",
-	},
-		[]string{
-			"cipher",
-			"repo_key",
-			"stanza",
-		})
-	pgbrStanzaBackupInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_info",
-		Help: "Backup info.",
-	},
-		[]string{
-			"backrest_ver",
-			"backup_name",
-			"backup_type",
-			"database_id",
-			"pg_version",
-			"prior",
-			"repo_key",
-			"stanza",
-			"wal_start",
-			"wal_stop"})
-	pgbrStanzaBackupDurationMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_duration_seconds",
-		Help: "Backup duration.",
-	},
-		[]string{
-			"backup_name",
-			"backup_type",
-			"database_id",
-			"repo_key",
-			"stanza",
-			"start_time",
-			"stop_time"})
-	// The 'database size' for text pgBackRest output
-	// (or "backup":"info":"size" for json pgBackRest output)
-	// is the full uncompressed size of the database.
-	pgbrStanzaBackupDatabaseSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_size_bytes",
-		Help: "Full uncompressed size of the database.",
-	},
-		[]string{
-			"backup_name",
-			"backup_type",
-			"database_id",
-			"repo_key",
-			"stanza"})
-	// The 'database backup size' for text pgBackRest output
-	// (or "backup":"info":"delta" for json pgBackRest output)
-	// is the amount of data in the database
-	// to actually backup (these will be the same for full backups).
-	pgbrStanzaBackupDatabaseBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_delta_bytes",
-		Help: "Amount of data in the database to actually backup.",
-	},
-		[]string{
-			"backup_name",
-			"backup_type",
-			"database_id",
-			"repo_key",
-			"stanza"})
-	// The 'backup set size' for text pgBackRest output
-	// (or "backup":"info":"repository":"size" for json pgBackRest output)
-	// includes all the files from this backup and
-	// any referenced backups in the repository that are required
-	// to restore the database from this backup.
-	// Repository 'backup set size' reflect compressed file sizes
-	// if compression is enabled in pgBackRest or the filesystem.
-	pgbrStanzaBackupRepoBackupSetSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_repo_size_bytes",
-		Help: "Full compressed files size to restore the database from backup.",
-	},
-		[]string{
-			"backup_name",
-			"backup_type",
-			"database_id",
-			"repo_key",
-			"stanza"})
-	// The 'backup size' for text pgBackRest output
-	// (or "backup":"info":"repository":"delta" for json pgBackRest output)
-	// includes only the files in this backup
-	// (these will also be the same for full backups).
-	// Repository 'backup size' reflect compressed file sizes
-	// if compression is enabled in pgBackRest or the filesystem.
-	pgbrStanzaBackupRepoBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_repo_delta_bytes",
-		Help: "Compressed files size in backup.",
-	},
-		[]string{
-			"backup_name",
-			"backup_type",
-			"database_id",
-			"repo_key",
-			"stanza"})
-	pgbrStanzaBackupLastFullMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_full_since_last_completion_seconds",
-		Help: "Seconds since the last completed full backup.",
-	},
-		[]string{"stanza"})
-	// Differential backup is always based on last full,
-	// if the last backup was full, the metric will take full backup value.
-	pgbrStanzaBackupLastDiffMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_diff_since_last_completion_seconds",
-		Help: "Seconds since the last completed full or differential backup.",
-	},
-		[]string{"stanza"})
-	// Incremental backup is always based on last full or differential,
-	// if the last backup was full or differential, the metric will take
-	// full or differential backup value.
-	pgbrStanzaBackupLastIncrMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_backup_incr_since_last_completion_seconds",
-		Help: "Seconds since the last completed full, differential or incremental backup.",
-	},
-		[]string{"stanza"})
-	pgbrWALArchivingMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "pgbackrest_wal_archive_status",
-		Help: "Current WAL archive status.",
-	},
-		[]string{
-			"database_id",
-			"pg_version",
-			"repo_key",
-			"stanza",
-			"wal_max",
-			"wal_min"})
-	execCommand = exec.Command
-)
+var execCommand = exec.Command
 
 // https://golang.org/pkg/time/#Time.Format
 const layout = "2006-01-02 15:04:05"
@@ -637,4 +502,20 @@ func stanzaNotInExclude(stanza string, listExclude []string) bool {
 		}
 	}
 	return true
+}
+
+func getExporterMetrics(exporterVer string, setUpMetricValueFun setUpMetricValueFunType) {
+	err := setUpMetricValueFun(
+		pgbrExporterInfoMetric,
+		1,
+		exporterVer,
+	)
+	if err != nil {
+		log.Println(
+			"[ERROR] Metric pgbackrest_exporter_info set up failed;",
+			"value:", 1, ";",
+			"labels:",
+			exporterVer,
+		)
+	}
 }

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -88,6 +88,10 @@ func main() {
 	log.Printf("[INFO] Use port %s and HTTP endpoint %s", *promPort, *promPath)
 	// Start exporter.
 	backrest.StartPromEndpoint()
+	// Set up exporter info metric.
+	// There is no need to reset metric every time,
+	// it is set up once at startup.
+	backrest.GetExporterInfo(version)
 	for {
 		// Reset metrics.
 		backrest.ResetMetrics()


### PR DESCRIPTION
Added new metric:
* `pgbackrest_exporter_info` - information about pgBackRest exporter.

Refactoring:
* variables definition for metrics has been moved to `backrest_exporter.go`.

Also added build for arm64 on linux in make file.