### PR TITLE
Add end-to-end tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ ENV EXPORTER_ENDPOINT="/metrics" \
     STANZA_INCLUDE="" \
     STANZA_EXCLUDE="" \
     COLLECT_INTERVAL="600"
-COPY --from=builder /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter
-RUN chmod 755 /etc/pgbackrest/pgbackrest_exporter
+COPY --from=builder --chmod=755 /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter
 LABEL \
     org.opencontainers.image.version="${REPO_BUILD_TAG}" \
     org.opencontainers.image.source="https://github.com/woblerr/pgbackrest_exporter"

--- a/README.md
+++ b/README.md
@@ -285,3 +285,17 @@ sudo systemctl enable pgbackrest_exporter.service
 sudo systemctl restart pgbackrest_exporter.service
 systemctl -l status pgbackrest_exporter.service
 ```
+
+### Running tests
+
+Run the unit tests:
+
+```bash
+make test
+```
+
+Run the end-to-end tests:
+
+```bash
+make test-e2e
+```

--- a/e2e_tests/Dockerfile
+++ b/e2e_tests/Dockerfile
@@ -1,0 +1,46 @@
+ARG BACKREST_VERSION="2.36"
+ARG PG_VERSION="13"
+
+FROM golang:1.17-buster AS builder
+ARG REPO_BUILD_TAG
+COPY . /build
+WORKDIR /build
+RUN CGO_ENABLED=0 go build \
+        -mod=vendor -trimpath \
+        -ldflags "-X main.version=${REPO_BUILD_TAG}" \
+        -o pgbackrest_exporter pgbackrest_exporter.go
+
+FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}
+ARG REPO_BUILD_TAG
+ARG PG_VERSION
+ENV BACKREST_USER="postgres" \
+    BACKREST_GROUP="postgres" \
+    EXPORTER_PORT="9854"
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        curl \
+        ca-certificates \
+        gnupg \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && echo "deb http://apt.postgresql.org/pub/repos/apt/ focal-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        postgresql-${PG_VERSION} \
+        postgresql-contrib-${PG_VERSION} \
+    && apt-get autoremove -y \
+    && apt-get autopurge -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p \
+        /var/lib/pgbackrest/repo1 \
+        /var/lib/pgbackrest/repo1 \
+        /e2e_tests
+COPY --chown=${BACKREST_USER}:${BACKREST_GROUP} \
+        ./e2e_tests/postgresql.auto.conf \
+        /var/lib/postgresql/${PG_VERSION}/main/postgresql.auto.conf
+COPY ./e2e_tests/pgbackrest.conf /etc/pgbackrest/pgbackrest.conf
+COPY --chmod=755 ./e2e_tests/prepare_e2e.sh /e2e_tests/prepare_e2e.sh
+COPY --from=builder --chmod=755 /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter
+ENTRYPOINT ["/entrypoint.sh"]
+CMD /e2e_tests/prepare_e2e.sh
+EXPOSE ${EXPORTER_PORT}

--- a/e2e_tests/pgbackrest.conf
+++ b/e2e_tests/pgbackrest.conf
@@ -1,0 +1,14 @@
+[demo]
+pg1-path=/var/lib/postgresql/13/main
+
+[global]
+repo1-path=/var/lib/pgbackrest/repo1
+repo1-retention-diff=2
+repo1-retention-full=2
+repo2-path=/var/lib/postgresql/repo2
+repo2-retention-diff=2
+repo2-retention-full=2
+start-fast=y
+
+[global:archive-push]
+compress-level=3

--- a/e2e_tests/postgresql.auto.conf
+++ b/e2e_tests/postgresql.auto.conf
@@ -1,0 +1,6 @@
+archive_command = 'pgbackrest --stanza=demo archive-push %p'
+archive_mode = on
+listen_addresses = '*'
+log_line_prefix = ''
+max_wal_senders = 3
+wal_level = replica

--- a/e2e_tests/prepare_e2e.sh
+++ b/e2e_tests/prepare_e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on errors and on command pipe failures.
 set -e

--- a/e2e_tests/prepare_e2e.sh
+++ b/e2e_tests/prepare_e2e.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Exit on errors and on command pipe failures.
+set -e
+
+PG_CLUSTER="main"
+PG_DATABASE="test_db"
+PG_BIN="/usr/lib/postgresql/13/bin"
+PG_DATA="/var/lib/postgresql/13/${PG_CLUSTER}"
+BACKREST_STANZA="demo"
+
+# Enable checksums.
+${PG_BIN}/pg_checksums -e -D ${PG_DATA}
+# Start postgres.
+pg_ctlcluster 13 ${PG_CLUSTER} start
+# Create  database.
+psql -c "create database ${PG_DATABASE}"
+db_oid=$(psql -t -c "select OID from pg_database where datname='demo_db';")
+# Create stanza.
+pgbackrest stanza-create --stanza ${BACKREST_STANZA} --log-level-console warn
+# Create full backup for stanza  in repo1.
+pgbackrest backup --stanza ${BACKREST_STANZA} --type full --log-level-console warn
+# Create full bakup for stanza in repo2.
+pgbackrest backup --stanza ${BACKREST_STANZA} --type full --repo 2 --log-level-console warn 
+# Currupt database file.
+db_file=$(find ${PG_DATA}/base/${db_oid} -type f -regextype egrep -regex '.*/([0-9]){4}$' -print | head -n 1)
+echo "currupt" >> ${db_file} 
+# Create diff backup with corrupted databse file in repo1.
+pgbackrest backup --stanza ${BACKREST_STANZA} --type diff  --repo 2 --log-level-console warn
+# Run pgbackrest_exporter.
+/etc/pgbackrest/pgbackrest_exporter

--- a/e2e_tests/run_e2e.sh
+++ b/e2e_tests/run_e2e.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+PORT="${1}"
+
+get_metrics() {
+    local exporter_url="http://localhost:${1}/metrics"
+    cnt=$(curl -s ${exporter_url} | grep -E "${2}" | wc -l | tr -d ' ')
+    echo "${cnt}"
+}
+
+# Format: regex | repetitions
+declare -a REGEX_LIST=(
+    '^pgbackrest_backup_delta_bytes{.*}|3'
+    '^pgbackrest_backup_duration_seconds{.*}|3'
+    '^pgbackrest_backup_error_status{.*,backup_type="full",.*} 0$|2'
+    '^pgbackrest_backup_error_status{.*,backup_type="diff",.*,repo_key="2".*} 1$|1'
+    '^pgbackrest_backup_diff_since_last_completion_seconds{.*}|1'
+    '^pgbackrest_backup_full_since_last_completion_seconds{.*}|1'
+    '^pgbackrest_backup_incr_since_last_completion_seconds{.*}|1'
+    '^pgbackrest_backup_info{.*} 1$|3'
+    '^pgbackrest_backup_repo_delta_bytes{.*}|3'
+    '^pgbackrest_backup_repo_size_bytes{.*}|3'
+    '^pgbackrest_backup_size_bytes{.*}|3'
+    '^pgbackrest_exporter_info{.*} 1$|1'
+    '^pgbackrest_repo_status{.*,repo_key="1".*} 0$|1'
+    '^pgbackrest_repo_status{.*,repo_key="2".*} 0$|1'
+    '^pgbackrest_stanza_status{.*} 0$|1'
+    '^pgbackrest_wal_archive_status{.*,repo_key="1",.*}|1'
+    '^pgbackrest_wal_archive_status{.*,repo_key="2",.*}|1'
+)
+
+# Check results
+for i in "${REGEX_LIST[@]}"
+do
+    regex=$(echo ${i} | cut -f1 -d'|')
+    cnt=$(echo ${i} | cut -f2 -d'|')
+    metric_cnt=$(get_metrics "${PORT}" "${regex}") 
+    if [[ ${metric_cnt} != ${cnt} ]]; then
+        echo "[ERROR] on regex '${regex}': get=${metric_cnt}, want=${cnt}"
+        exit 1
+    fi
+done
+
+echo "[INFO] all tests passed"
+exit 0


### PR DESCRIPTION
* Added end-to-end tests to check metrics on real backups.
   Short description:
    * launch PostgreSQL in container ;
    * create several backups by pgBackRest;
    * launch pgbackrest_exporter in the same container; 
    * validate the metrics by external  `run_e2e.sh` script.

* Updated variable declaration in Makefile. Expressions are evaluated only once.
* Updated Dockerfile  for pgbackrest_exporter:  file permission now  in  COPY layer.