### PR TITLE
Up base docker image to v0.11.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env: 
       backrest_version: "2.38"
-      docker_backrest_version: "v0.10"
+      docker_backrest_version: "v0.11"
       build_platforms: "linux/amd64,linux/arm64"
     steps:
       - name: Set up go 1.17

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BACKREST_VERSION="2.38-v0.10"
+ARG BACKREST_VERSION="2.38"
+ARG DOCKER_BACKREST_VERSION="v0.11"
 ARG REPO_BUILD_TAG="unknown"
 
 FROM golang:1.17-buster AS builder
@@ -10,7 +11,7 @@ RUN CGO_ENABLED=0 go build \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
         -o pgbackrest_exporter pgbackrest_exporter.go
 
-FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}
+FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}-${DOCKER_BACKREST_VERSION}
 ARG REPO_BUILD_TAG
 ENV EXPORTER_ENDPOINT="/metrics" \
     EXPORTER_PORT="9854" \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_REV := $(shell git describe --abbrev=7 --always)
 SERVICE_CONF_DIR := /etc/systemd/system
 HTTP_PORT := 9854
 BACKREST_VERSION := 2.38
-DOCKER_BACKREST_VERSION := v0.10
+DOCKER_BACKREST_VERSION := v0.11
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 DOCKER_CONTAINER_E2E := $(shell docker ps -a -q -f name=$(APP_NAME)_e2e)
 HTTP_PORT_E2E := $(shell echo $$((10000 + ($$RANDOM % 10000))))
@@ -20,7 +20,7 @@ test:
 test-e2e:
 	@echo "Run end-to-end tests for $(APP_NAME)"
 	@if [ -n "$(DOCKER_CONTAINER_E2E)" ]; then docker rm -f "$(DOCKER_CONTAINER_E2E)"; fi;
-	DOCKER_BUILDKIT=1 docker build --pull -f e2e_tests/Dockerfile --build-arg BACKREST_VERSION=$(BACKREST_VERSION)-$(DOCKER_BACKREST_VERSION) -t $(APP_NAME)_e2e .
+	DOCKER_BUILDKIT=1 docker build --pull -f e2e_tests/Dockerfile --build-arg BACKREST_VERSION=$(BACKREST_VERSION) --build-arg DOCKER_BACKREST_VERSION=$(DOCKER_BACKREST_VERSION) -t $(APP_NAME)_e2e .
 	$(call e2e_basic)
 	$(call e2e_tls_auth,/e2e_tests/web_config_empty.yml,false,false)
 	$(call e2e_tls_auth,/e2e_tests/web_config_TLS_noAuth.yml,true,false)
@@ -58,13 +58,13 @@ dist:
 docker:
 	@echo "Build $(APP_NAME) docker container"
 	@echo "Version $(BRANCH)-$(GIT_REV)"
-	DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) --build-arg BACKREST_VERSION=$(BACKREST_VERSION)-$(DOCKER_BACKREST_VERSION) -t $(APP_NAME) .
+	DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) --build-arg BACKREST_VERSION=$(BACKREST_VERSION) --build-arg DOCKER_BACKREST_VERSION=$(DOCKER_BACKREST_VERSION) -t $(APP_NAME) .
 
 .PHONY: docker-alpine
 docker-alpine:
 	@echo "Build $(APP_NAME) alpine docker container"
 	@echo "Version $(BRANCH)-$(GIT_REV)"
-	DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) --build-arg BACKREST_VERSION=$(BACKREST_VERSION)-alpine-$(DOCKER_BACKREST_VERSION) -t $(APP_NAME)-alpine .
+	DOCKER_BUILDKIT=1 docker build --pull -f Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) --build-arg BACKREST_VERSION=$(BACKREST_VERSION)-alpine --build-arg DOCKER_BACKREST_VERSION=$(DOCKER_BACKREST_VERSION) -t $(APP_NAME)-alpine .
 
 .PHONY: prepare-service
 prepare-service:

--- a/README.md
+++ b/README.md
@@ -175,8 +175,44 @@ This flag works for `pgBackRest >= v2.38`.<br>
 For earlier pgBackRest versions there will be an error like: `option 'type' not valid for command 'info'`.
 
 ### Building and running docker
+
 By default, pgBackRest version is `2.38`. Another version can be specified via arguments.
 For base image used [docker-pgbackrest](https://github.com/woblerr/docker-pgbackrest) image.
+
+Environment variables supported by this image:
+* all environment variables from [docker-pgbackrest](https://github.com/woblerr/docker-pgbackrest#docker-pgbackrest)  image;
+* `EXPORTER_ENDPOINT` - metrics endpoint, default `/metrics`;
+* `EXPORTER_PORT` - port for prometheus metrics to listen on, default `9854`;
+* `STANZA_INCLUDE` - specific stanza for collecting metrics, default `""`;
+* `STANZA_EXCLUDE` - specific stanza to exclude from collecting metrics, default `""`;
+* `COLLECT_INTERVAL` - collecting metrics interval in seconds, default `600`;
+* `BACKUP_TYPE` - specific backup type for collecting metrics, default `""`.
+
+#### Pull
+
+Change `tag` to the release number.
+
+* Docker Hub:
+
+```bash
+docker pull woblerr/pgbackrest_exporter:tag
+```
+
+```bash
+docker pull woblerr/pgbackrest_exporter:tag-alpine
+```
+
+* GitHub Registry:
+
+```bash
+docker pull ghcr.io/woblerr/pgbackrest_exporter:tag
+```
+
+```bash
+docker pull ghcr.io/woblerr/pgbackrest_exporter:tag-alpine
+```
+
+#### Build
 
 ```bash
 make docker
@@ -196,14 +232,7 @@ docker build -f Dockerfile --build-arg BACKREST_VERSION=2.34 -t pgbackrest_expor
 docker build -f Dockerfile --build-arg BACKREST_VERSION=2.34-alpine -t pgbackrest_exporter-alpine .
 ```
 
-Environment variables supported by this image:
-* all environment variables from [docker-pgbackrest](https://github.com/woblerr/docker-pgbackrest#docker-pgbackrest)  image;
-* `EXPORTER_ENDPOINT` - metrics endpoint, default `/metrics`;
-* `EXPORTER_PORT` - port for prometheus metrics to listen on, default `9854`;
-* `STANZA_INCLUDE` - specific stanza for collecting metrics, default `""`;
-* `STANZA_EXCLUDE` - specific stanza to exclude from collecting metrics, default `""`;
-* `COLLECT_INTERVAL` - collecting metrics interval in seconds, default `600`;
-* `BACKUP_TYPE` - specific backup type for collecting metrics, default `""`.
+#### Run
 
 You will need to mount the necessary directories or files inside the container.
 

--- a/e2e_tests/Dockerfile
+++ b/e2e_tests/Dockerfile
@@ -1,4 +1,5 @@
-ARG BACKREST_VERSION="2.38-v0.10"
+ARG BACKREST_VERSION="2.38"
+ARG DOCKER_BACKREST_VERSION="v0.11"
 ARG PG_VERSION="13"
 
 FROM golang:1.17-buster AS builder
@@ -10,7 +11,7 @@ RUN CGO_ENABLED=0 go build \
         -ldflags "-X main.version=${REPO_BUILD_TAG}" \
         -o pgbackrest_exporter pgbackrest_exporter.go
 
-FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}
+FROM ghcr.io/woblerr/pgbackrest:${BACKREST_VERSION}-${DOCKER_BACKREST_VERSION}
 ARG REPO_BUILD_TAG
 ARG PG_VERSION
 ENV BACKREST_USER="postgres" \


### PR DESCRIPTION
* Updated base docker image to `v0.11`.
  Starting from this version, the `UTC` time zone is used inside the container. For custom timezone - use `TZ` environment variable for `docker run` command.
* Added information about pulling image to README.