### PR TITLE
Add metric for number of databases in backups.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV EXPORTER_ENDPOINT="/metrics" \
     COLLECT_INTERVAL="600" \
     BACKUP_TYPE="" \
     VERBOSE_WAL="false" \
+    DATABASE_COUNT="false" \
     DATABASE_COUNT_LATEST="false"
 COPY --chmod=755 docker_files/run_exporter.sh /run_exporter.sh
 COPY --from=builder --chmod=755 /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -57,13 +57,14 @@ func ResetMetrics() {
 	pgbrStanzaBackupRepoBackupSetSizeMetric.Reset()
 	pgbrStanzaBackupRepoBackupSizeMetric.Reset()
 	pgbrStanzaBackupErrorMetric.Reset()
+	pgbrStanzaBackupDatabasesMetric.Reset()
 	pgbrStanzaBackupSinceLastCompletionSecondsMetric.Reset()
 	pgbrStanzaBackupLastDatabasesMetric.Reset()
 	pgbrWALArchivingMetric.Reset()
 }
 
 // GetPgBackRestInfo get and parse pgBackRest info and set metrics
-func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []string, stanzasExclude []string, backupDBCountLatest, verboseWAL bool, logger log.Logger) {
+func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []string, stanzasExclude []string, backupDBCount, backupDBCountLatest, verboseWAL bool, logger log.Logger) {
 	// To calculate the time elapsed since the last completed full, differential or incremental backup.
 	// For all stanzas values are calculated relative to one value.
 	currentUnixTime := time.Now().Unix()
@@ -90,7 +91,7 @@ func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []s
 					getStanzaMetrics(singleStanza.Name, singleStanza.Status.Code, setUpMetricValue, logger)
 					getRepoMetrics(singleStanza.Name, singleStanza.Repo, setUpMetricValue, logger)
 					// Last backups for current stanza
-					lastBackups := getBackupMetrics(singleStanza.Name, singleStanza.Backup, singleStanza.DB, setUpMetricValue, logger)
+					lastBackups := getBackupMetrics(config, configIncludePath, singleStanza.Name, singleStanza.Backup, singleStanza.DB, backupDBCount, setUpMetricValue, logger)
 					getBackupLastMetrics(config, configIncludePath, singleStanza.Name, lastBackups, backupDBCountLatest, currentUnixTime, setUpMetricValue, logger)
 					getWALMetrics(singleStanza.Name, singleStanza.Archive, singleStanza.DB, verboseWAL, setUpMetricValue, logger)
 				}

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -59,7 +59,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 	}{
 		{
 			"GetPgBackRestInfoGoodDataReturn",
-			args{"", "", "", []string{""}, []string{""}, false, true, false},
+			args{"", "", "", []string{""}, []string{""}, true, true, false},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
@@ -77,7 +77,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			""},
 		{
 			"GetPgBackRestInfoGoodDataReturnWithWarn",
-			args{"", "", "", []string{""}, []string{""}, false, true, false},
+			args{"", "", "", []string{""}, []string{""}, true, true, false},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -47,6 +47,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 		backupType          string
 		stanzas             []string
 		stanzasExclude      []string
+		backupDBCount       bool
 		backupDBCountLatest bool
 		verboseWAL          bool
 	}
@@ -58,7 +59,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 	}{
 		{
 			"GetPgBackRestInfoGoodDataReturn",
-			args{"", "", "", []string{""}, []string{""}, true, false},
+			args{"", "", "", []string{""}, []string{""}, false, true, false},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
@@ -76,7 +77,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			""},
 		{
 			"GetPgBackRestInfoGoodDataReturnWithWarn",
-			args{"", "", "", []string{""}, []string{""}, true, false},
+			args{"", "", "", []string{""}, []string{""}, false, true, false},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
@@ -94,7 +95,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="pgBackRest message" err="WARN: environment contains invalid option 'test'`},
 		{
 			"GetPgBackRestInfoBadDataReturn",
-			args{"", "", "", []string{""}, []string{""}, false, false},
+			args{"", "", "", []string{""}, []string{""}, false, false, false},
 			mockStruct{
 				``,
 				`msg="pgBackRest message" err="ERROR: [029]: missing '=' in key/value at line 9: test"`,
@@ -103,7 +104,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="Get data from pgBackRest failed" err="exit status 29`},
 		{
 			"GetPgBackRestInfoZeroDataReturn",
-			args{"", "", "", []string{""}, []string{""}, false, false},
+			args{"", "", "", []string{""}, []string{""}, false, false, false},
 			mockStruct{
 				`[]`,
 				``,
@@ -112,7 +113,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="No backup data returned"`},
 		{
 			"GetPgBackRestInfoJsonUnmarshalFail",
-			args{"", "", "", []string{""}, []string{""}, false, false},
+			args{"", "", "", []string{""}, []string{""}, false, false, false},
 			mockStruct{
 				`[{}`,
 				``,
@@ -121,7 +122,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="Parse JSON failed" err="unexpected end of JSON input"`},
 		{
 			"GetPgBackRestInfoEqualIncludeExcludeLists",
-			args{"", "", "", []string{"demo"}, []string{"demo"}, false, false},
+			args{"", "", "", []string{"demo"}, []string{"demo"}, false, false, false},
 			mockStruct{
 				``,
 				``,
@@ -143,6 +144,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 				tt.args.backupType,
 				tt.args.stanzas,
 				tt.args.stanzasExclude,
+				tt.args.backupDBCount,
 				tt.args.backupDBCountLatest,
 				tt.args.verboseWAL,
 				lc,

--- a/backrest/backrest_metrics.go
+++ b/backrest/backrest_metrics.go
@@ -127,6 +127,16 @@ var (
 			"database_id",
 			"repo_key",
 			"stanza"})
+	pgbrStanzaBackupDatabasesMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_databases",
+		Help: "Number of databases in backup.",
+	},
+		[]string{
+			"backup_name",
+			"backup_type",
+			"database_id",
+			"repo_key",
+			"stanza"})
 	// Differential backup is always based on last full,
 	// if the last backup was full, the metric will take full backup value.
 	// Incremental backup is always based on last full or differential,

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -242,7 +242,134 @@ func TestGetRepoMetricsErrorsAndDebugs(t *testing.T) {
 
 // All metrics exist and all labels are corrected.
 // pgBackrest version = latest.
+// With '--backrest.database-count' flag.
 func TestGetBackupMetrics(t *testing.T) {
+	type args struct {
+		config              string
+		configIncludePath   string
+		stanzaName          string
+		backupData          []backup
+		dbData              []db
+		backupDBCount       bool
+		setUpMetricValueFun setUpMetricValueFunType
+		testText            string
+		testLastBackups     lastBackupsStruct
+	}
+	templateMetrics := `# HELP pgbackrest_backup_databases Number of databases in backup.
+# TYPE pgbackrest_backup_databases gauge
+pgbackrest_backup_databases{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 1
+# HELP pgbackrest_backup_delta_bytes Amount of data in the database to actually backup.
+# TYPE pgbackrest_backup_delta_bytes gauge
+pgbackrest_backup_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
+# HELP pgbackrest_backup_duration_seconds Backup duration.
+# TYPE pgbackrest_backup_duration_seconds gauge
+pgbackrest_backup_duration_seconds{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo",start_time="2021-06-07 12:24:23",stop_time="2021-06-07 12:24:26"} 3
+# HELP pgbackrest_backup_error_status Backup error status.
+# TYPE pgbackrest_backup_error_status gauge
+pgbackrest_backup_error_status{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 1
+# HELP pgbackrest_backup_info Backup info.
+# TYPE pgbackrest_backup_info gauge
+pgbackrest_backup_info{backrest_ver="2.41",backup_name="20210607-092423F",backup_type="full",database_id="1",lsn_start="0/2000028",lsn_stop="0/2000100",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
+# HELP pgbackrest_backup_repo_delta_bytes Compressed files size in backup.
+# TYPE pgbackrest_backup_repo_delta_bytes gauge
+pgbackrest_backup_repo_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
+# HELP pgbackrest_backup_repo_size_bytes Full compressed files size to restore the database from backup.
+# TYPE pgbackrest_backup_repo_size_bytes gauge
+pgbackrest_backup_repo_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.969514e+06
+# HELP pgbackrest_backup_size_bytes Full uncompressed size of the database.
+# TYPE pgbackrest_backup_size_bytes gauge
+pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
+`
+	tests := []struct {
+		name         string
+		args         args
+		mockTestData mockStruct
+	}{
+		{
+			"getBackupMetrics",
+			args{
+				"",
+				"",
+				templateStanza(
+					"000000010000000000000004",
+					"000000010000000000000001",
+					[]databaseRef{{"postgres", 13425}},
+					true).Name,
+				templateStanza(
+					"000000010000000000000004",
+					"000000010000000000000001",
+					[]databaseRef{{"postgres", 13425}},
+					true).Backup,
+				templateStanza(
+					"000000010000000000000004",
+					"000000010000000000000001",
+					[]databaseRef{{"postgres", 13425}},
+					true).DB,
+				true,
+				setUpMetricValue,
+				templateMetrics,
+				templateLastBackup(),
+			},
+			mockStruct{
+				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
+					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
+					`"backup":[{"archive":{"start":"000000010000000000000002","stop":"000000010000000000000002"},` +
+					`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":1},` +
+					`"database-ref":[{"name":"postgres","oid":13412}],"error":true,"error-list":["base/1/3351"],` +
+					`"info":{"delta":24316343,"repository":{"delta":2969512,"size":2969512},"size":24316343},` +
+					`"label":"20210614-213200F","lsn":{"start":"0/2000028","stop":"0/2000100"},"prior":null,"reference":null,"timestamp":{"start":1623706320,` +
+					`"stop":1623706322},"type":"full"}],"cipher":"none","db":[{"id":1,"repo-key":1,` +
+					`"system-id":6970977677138971135,"version":"13"}],"name":"demo","repo":[{"cipher":"none",` +
+					`"key":1,"status":{"code":0,"message":"ok"}}],"status":{"code":0,"lock":{"backup":` +
+					`{"held":false}},"message":"ok"}}]`,
+				"",
+				0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ResetMetrics()
+			mockData = tt.mockTestData
+			execCommand = fakeExecCommand
+			defer func() { execCommand = exec.Command }()
+			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(
+				pgbrStanzaBackupInfoMetric,
+				pgbrStanzaBackupDurationMetric,
+				pgbrStanzaBackupDatabaseSizeMetric,
+				pgbrStanzaBackupDatabaseBackupSizeMetric,
+				pgbrStanzaBackupRepoBackupSetSizeMetric,
+				pgbrStanzaBackupRepoBackupSizeMetric,
+				pgbrStanzaBackupErrorMetric,
+				pgbrStanzaBackupDatabasesMetric,
+			)
+			metricFamily, err := reg.Gather()
+			if err != nil {
+				fmt.Println(err)
+			}
+			out := &bytes.Buffer{}
+			for _, mf := range metricFamily {
+				if _, err := expfmt.MetricFamilyToText(out, mf); err != nil {
+					panic(err)
+				}
+			}
+			if tt.args.testText != out.String() && !reflect.DeepEqual(tt.args.testLastBackups, testLastBackups) {
+				t.Errorf(
+					"\nVariables do not match, metrics:\n%s\nwant:\n%s\nlastBackups:\n%v\nwant:\n%v",
+					tt.args.testText, out.String(),
+					tt.args.testLastBackups, testLastBackups,
+				)
+			}
+		})
+	}
+}
+
+// Absent metrics:
+//	* pgbackrest_backup_databases
+// pgBackrest version < 2.41.
+func TestGetBackupMetricsDBsAbsent(t *testing.T) {
 	type args struct {
 		config              string
 		configIncludePath   string
@@ -277,8 +404,9 @@ pgbackrest_backup_repo_size_bytes{backup_name="20210607-092423F",backup_type="fu
 pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
 `
 	tests := []struct {
-		name string
-		args args
+		name         string
+		args         args
+		mockTestData mockStruct
 	}{
 		{
 			"getBackupMetrics",
@@ -300,16 +428,24 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 					"000000010000000000000001",
 					[]databaseRef{{"postgres", 13425}},
 					true).DB,
-				false,
+				true,
 				setUpMetricValue,
 				templateMetrics,
 				templateLastBackup(),
+			},
+			mockStruct{
+				"",
+				"ERROR: [027]: option 'set' is currently only valid for text output",
+				27,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetMetrics()
+			mockData = tt.mockTestData
+			execCommand = fakeExecCommand
+			defer func() { execCommand = exec.Command }()
 			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
@@ -320,6 +456,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				pgbrStanzaBackupRepoBackupSetSizeMetric,
 				pgbrStanzaBackupRepoBackupSizeMetric,
 				pgbrStanzaBackupErrorMetric,
+				pgbrStanzaBackupDatabasesMetric,
 			)
 			metricFamily, err := reg.Gather()
 			if err != nil {
@@ -344,6 +481,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 
 // Absent metrics:
 //	* pgbackrest_backup_error_status
+//	* pgbackrest_backup_databases
 // Labels:
 //  * lsn_start=""
 //	* lsn_stop=""
@@ -381,8 +519,9 @@ pgbackrest_backup_repo_size_bytes{backup_name="20210607-092423F",backup_type="fu
 pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
 `
 	tests := []struct {
-		name string
-		args args
+		name         string
+		args         args
+		mockTestData mockStruct
 	}{
 		{
 			"getBackupMetricsErrorAbsent",
@@ -398,16 +537,24 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				templateStanzaErrorAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001").DB,
-				false,
+				true,
 				setUpMetricValue,
 				templateMetrics,
 				templateLastBackup(),
+			},
+			mockStruct{
+				"",
+				"ERROR: [027]: option 'set' is currently only valid for text output",
+				27,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetMetrics()
+			mockData = tt.mockTestData
+			execCommand = fakeExecCommand
+			defer func() { execCommand = exec.Command }()
 			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
@@ -441,6 +588,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 
 // Absent metrics:
 //	* pgbackrest_backup_error_status
+//	* pgbackrest_backup_databases
 // Labels:
 // 	* repo_key="0"
 //  * lsn_start=""
@@ -479,8 +627,9 @@ pgbackrest_backup_repo_size_bytes{backup_name="20210607-092423F",backup_type="fu
 pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="0",stanza="demo"} 2.4316343e+07
 `
 	tests := []struct {
-		name string
-		args args
+		name         string
+		args         args
+		mockTestData mockStruct
 	}{
 		{
 			"getBackupMetricsRepoAbsent",
@@ -501,11 +650,19 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				templateMetrics,
 				templateLastBackup(),
 			},
+			mockStruct{
+				"",
+				"ERROR: [027]: option 'set' is currently only valid for text output",
+				27,
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetMetrics()
+			mockData = tt.mockTestData
+			execCommand = fakeExecCommand
+			defer func() { execCommand = exec.Command }()
 			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
@@ -550,8 +707,9 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 		debugsCount         int
 	}
 	tests := []struct {
-		name string
-		args args
+		name         string
+		args         args
+		mockTestData mockStruct
 	}{
 		{
 			"getBackupMetricsLogError",
@@ -573,15 +731,34 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 					"000000010000000000000001",
 					[]databaseRef{{"postgres", 13425}},
 					true).DB,
-				false,
+				true,
 				fakeSetUpMetricValue,
-				7,
-				7,
+				8,
+				8,
+			},
+			mockStruct{
+				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
+					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
+					`"backup":[{"archive":{"start":"000000010000000000000002","stop":"000000010000000000000002"},` +
+					`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":1},` +
+					`"database-ref":[{"name":"postgres","oid":13412}],"error":true,"error-list":["base/1/3351"],` +
+					`"info":{"delta":24316343,"repository":{"delta":2969512,"size":2969512},"size":24316343},` +
+					`"label":"20210614-213200F","lsn":{"start":"0/2000028","stop":"0/2000100"},"prior":null,"reference":null,"timestamp":{"start":1623706320,` +
+					`"stop":1623706322},"type":"full"}],"cipher":"none","db":[{"id":1,"repo-key":1,` +
+					`"system-id":6970977677138971135,"version":"13"}],"name":"demo","repo":[{"cipher":"none",` +
+					`"key":1,"status":{"code":0,"message":"ok"}}],"status":{"code":0,"lock":{"backup":` +
+					`{"held":false}},"message":"ok"}}]`,
+				"",
+				0,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ResetMetrics()
+			mockData = tt.mockTestData
+			execCommand = fakeExecCommand
+			defer func() { execCommand = exec.Command }()
 			out := &bytes.Buffer{}
 			lc := log.NewLogfmtLogger(out)
 			getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, lc)

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -244,9 +244,12 @@ func TestGetRepoMetricsErrorsAndDebugs(t *testing.T) {
 // pgBackrest version = latest.
 func TestGetBackupMetrics(t *testing.T) {
 	type args struct {
+		config              string
+		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
+		backupDBCount       bool
 		setUpMetricValueFun setUpMetricValueFunType
 		testText            string
 		testLastBackups     lastBackupsStruct
@@ -280,6 +283,8 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetrics",
 			args{
+				"",
+				"",
 				templateStanza(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -295,6 +300,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 					"000000010000000000000001",
 					[]databaseRef{{"postgres", 13425}},
 					true).DB,
+				false,
 				setUpMetricValue,
 				templateMetrics,
 				templateLastBackup(),
@@ -304,7 +310,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetMetrics()
-			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -345,9 +351,12 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 //nolint:dupl
 func TestGetBackupMetricsErrorAbsent(t *testing.T) {
 	type args struct {
+		config              string
+		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
+		backupDBCount       bool
 		setUpMetricValueFun setUpMetricValueFunType
 		testText            string
 		testLastBackups     lastBackupsStruct
@@ -378,6 +387,8 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetricsErrorAbsent",
 			args{
+				"",
+				"",
 				templateStanzaErrorAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001").Name,
@@ -387,6 +398,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				templateStanzaErrorAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001").DB,
+				false,
 				setUpMetricValue,
 				templateMetrics,
 				templateLastBackup(),
@@ -396,7 +408,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetMetrics()
-			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -437,9 +449,12 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 //nolint:dupl
 func TestGetBackupMetricsRepoAbsent(t *testing.T) {
 	type args struct {
+		config              string
+		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
+		backupDBCount       bool
 		setUpMetricValueFun setUpMetricValueFunType
 		testText            string
 		testLastBackups     lastBackupsStruct
@@ -470,6 +485,8 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetricsRepoAbsent",
 			args{
+				"",
+				"",
 				templateStanzaRepoAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001").Name,
@@ -479,6 +496,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				templateStanzaRepoAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001").DB,
+				false,
 				setUpMetricValue,
 				templateMetrics,
 				templateLastBackup(),
@@ -488,7 +506,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ResetMetrics()
-			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -521,9 +539,12 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 
 func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 	type args struct {
+		config              string
+		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
+		backupDBCount       bool
 		setUpMetricValueFun setUpMetricValueFunType
 		errorsCount         int
 		debugsCount         int
@@ -535,6 +556,8 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 		{
 			"getBackupMetricsLogError",
 			args{
+				"",
+				"",
 				templateStanza(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -550,6 +573,7 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 					"000000010000000000000001",
 					[]databaseRef{{"postgres", 13425}},
 					true).DB,
+				false,
 				fakeSetUpMetricValue,
 				7,
 				7,
@@ -560,7 +584,7 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			out := &bytes.Buffer{}
 			lc := log.NewLogfmtLogger(out)
-			getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, lc)
+			getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, lc)
 			errorsOutputCount := strings.Count(out.String(), "level=error")
 			debugsOutputCount := strings.Count(out.String(), "level=debug")
 			if tt.args.errorsCount != errorsOutputCount || tt.args.debugsCount != debugsOutputCount {

--- a/docker_files/run_exporter.sh
+++ b/docker_files/run_exporter.sh
@@ -14,6 +14,9 @@ EXPORTER_COMMAND="/etc/pgbackrest/pgbackrest_exporter \
 # Check variable for enabling additional labels for WAL metrics.
 [ "${VERBOSE_WAL}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.verbose-wal"
 
+# Check variable for exposing the number of databases in backups.
+[ "${DATABASE_COUNT}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.database-count"
+
 # Check variable for exposing the number of databases in the latest backups.
 [ "${DATABASE_COUNT_LATEST}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.database-count-latest"
 

--- a/e2e_tests/prepare_e2e.sh
+++ b/e2e_tests/prepare_e2e.sh
@@ -32,7 +32,7 @@ echo "currupt" >> ${db_file}
 pgbackrest backup --stanza ${BACKREST_STANZA} --type diff  --repo 2 --log-level-console warn
 # Run pgbackrest_exporter.
 if [[ ! -z ${EXPORTER_CONFIG} ]]; then
-    $(${EXPORTER_BIN} --backrest.database-count-latest --prom.web-config=${EXPORTER_CONFIG})
+    $(${EXPORTER_BIN} --backrest.database-count --backrest.database-count-latest --prom.web-config=${EXPORTER_CONFIG})
 else
-    $(${EXPORTER_BIN} --backrest.database-count-latest)
+    $(${EXPORTER_BIN} --backrest.database-count --backrest.database-count-latest)
 fi

--- a/e2e_tests/run_e2e.sh
+++ b/e2e_tests/run_e2e.sh
@@ -45,6 +45,8 @@ declare -a REGEX_LIST=(
     '^pgbackrest_backup_error_status{.*,backup_type="full",.*} 0$|2'
     '^pgbackrest_backup_error_status{.*,backup_type="diff",.*,repo_key="2".*} 1$|1'
     '^pgbackrest_backup_since_last_completion_seconds{.*}|3'
+    '^pgbackrest_backup_databases{.*,backup_type="full",.*} 2|2'
+    '^pgbackrest_backup_databases{.*,backup_type="diff",.*,repo_key="2".*} 2|1'
     '^pgbackrest_backup_last_databases{.*}|3'
     '^pgbackrest_backup_info{.*} 1$|3'
     '^pgbackrest_backup_repo_delta_bytes{.*}|3'

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -56,6 +56,10 @@ func main() {
 			"backrest.backup-type",
 			"Specific backup type for collecting metrics. One of: [full, incr, diff].",
 		).Default("").String()
+		backrestBackupDBCount = kingpin.Flag(
+			"backrest.database-count",
+			"Exposing the number of databases in backups.",
+		).Default("false").Bool()
 		backrestBackupDBCountLatest = kingpin.Flag(
 			"backrest.database-count-latest",
 			"Exposing the number of databases in the latest backups.",
@@ -121,6 +125,11 @@ func main() {
 			"mgs", "Collecting metrics for specific backup type",
 			"type", *backrestBackupType)
 	}
+	if *backrestBackupDBCount {
+		level.Info(logger).Log(
+			"msg", "Exposing the number of databases in backups",
+			"database-count", *backrestBackupDBCount)
+	}
 	if *backrestBackupDBCountLatest {
 		level.Info(logger).Log(
 			"msg", "Exposing the number of databases in the latest backups",
@@ -155,6 +164,7 @@ func main() {
 			*backrestBackupType,
 			*backrestIncludeStanza,
 			*backrestExcludeStanza,
+			*backrestBackupDBCount,
 			*backrestBackupDBCountLatest,
 			*backrestVerboseWAL,
 			logger,


### PR DESCRIPTION
* Added new metric:
   * `pgbackrest_backup_databases `- number of databases in backup.
* Added `DATABASE_COUNT` variables to Dockerfile.
* Updated README.

