### PR TITLE
Add deb/rpm build to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,8 +28,7 @@ archives:
       darwin: macos
 
 nfpms:
-  -
-    id: pgbackrest_exporter
+  - id: pgbackrest_exporter
     package_name: pgbackrest_exporter
     builds:
       - pgbackrest_exporter

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ nfpms:
       - pgbackrest_exporter
     bindir: /usr/bin
     contents:
-      - src: pgbackrest_exporter.service
+      - src: pgbackrest_exporter.service.txt
         dst: /etc/systemd/system/pgbackrest_exporter.service
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,8 +42,6 @@ nfpms:
     formats:
       - deb
       - rpm
-    provides:
-      - pgbackrest_exporter
     bindir: /usr/bin
     contents:
       - src: pgbackrest_exporter.service.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,28 @@ archives:
       amd64: x86_64
       darwin: macos
 
+nfpms:
+  -
+    id: pgbackrest_exporter
+    package_name: pgbackrest_exporter
+    builds:
+      - pgbackrest_exporter
+    replacements:
+      amd64: x86_64
+    homepage: https://github.com/woblerr/pgbackrest_exporter/
+    maintainer: Anton Kurochkin <antkurochkin@gmail.com>
+    description: Prometheus exporter for pgBackRest
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    provides:
+      - pgbackrest_exporter
+    bindir: /usr/bin
+    contents:
+      - src: pgbackrest_exporter.service
+        dst: /etc/systemd/system/pgbackrest_exporter.service
+
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 

--- a/pgbackrest_exporter.service.txt
+++ b/pgbackrest_exporter.service.txt
@@ -1,0 +1,14 @@
+[Unit]
+Description=pgbackrest_exporter
+
+[Service]
+Type=simple
+Environment="EXPORTER_ENDPOINT=/metrics"
+Environment="EXPORTER_PORT=9854"
+Environment="COLLECT_INTERVAL=600"
+ExecStart=/usr/bin/pgbackrest_exporter --prom.endpoint=${EXPORTER_ENDPOINT} --prom.port=${EXPORTER_PORT} --collect.interval=${COLLECT_INTERVAL}
+Restart=always
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target 


### PR DESCRIPTION
Hi,
I've created this PR to set up the build of deb/rpm deliverables via goreleaser.
I think having this option can facilitate the deployment/usage of this exporter in Debian/RHEL based Linux environments.
Tried testing it in my forked repo but couldn't get the goreleaser action to execute.

I've added a copy of the systemd template with the binary path as installed by the deb/rpm, please let me know if that makes sense.

Cheers!