### PR TITLE
Exec pgbackrest_exporter; don't fork

### DIFF
--- a/docker_files/run_exporter.sh
+++ b/docker_files/run_exporter.sh
@@ -21,4 +21,4 @@ EXPORTER_COMMAND="/etc/pgbackrest/pgbackrest_exporter \
 [ "${DATABASE_COUNT_LATEST}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.database-count-latest"
 
 # Execute the final command.
-$(${EXPORTER_COMMAND})
+exec ${EXPORTER_COMMAND}


### PR DESCRIPTION
The container does not gracefully terminate in k8s when executing within a sub-shell

I have pgbackrest_exporter deployed on home lab running k3s version v1.24.8+k3s1 and am running it as a sidecar to a postgresql+timescaledb statefulset. Without overriding the command execution, pgbackrest_exporter does not gracefully terminate when the pod is restarted/deleted.

As a workaround, I'm specifying `command: ['/etc/pgbackrest/pgbackrest_exporter', '--collect.interval=600', '--prom.port=9854']` in the pod spec. However, I believe utilizing `exec` in run_exporter will work as well.