### PR TITLE
Don't use global stanzas variable.

### DIFF
--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -150,6 +150,7 @@ func getInfoData(config, configIncludePath, stanza, backupType, backupLabel stri
 }
 
 func parseResult(output []byte) ([]stanza, error) {
+	var stanzas []stanza
 	err := json.Unmarshal(output, &stanzas)
 	return stanzas, err
 }

--- a/backrest/backrest_struct.go
+++ b/backrest/backrest_struct.go
@@ -1,7 +1,5 @@
 package backrest
 
-var stanzas []stanza
-
 //	[{
 //	  "archive": [{}],
 //	  "cipher": "string",


### PR DESCRIPTION
The `parseResult()` function is used to get general information about stanza and information about specific backups for `*_databases` metrics.
When using a global variable, the stanza  data was overwritten, which could lead to incorrect data.