### PR TITLE
Add parallelization for collecting `*_databases` metrics.

### DIFF
--- a/backrest/backrest_backup_metrics_test.go
+++ b/backrest/backrest_backup_metrics_test.go
@@ -23,8 +23,6 @@ import (
 //nolint:dupl
 func TestGetBackupMetrics(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
@@ -33,10 +31,7 @@ func TestGetBackupMetrics(t *testing.T) {
 		testText            string
 		testLastBackups     lastBackupsStruct
 	}
-	templateMetrics := `# HELP pgbackrest_backup_databases Number of databases in backup.
-# TYPE pgbackrest_backup_databases gauge
-pgbackrest_backup_databases{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 1
-# HELP pgbackrest_backup_delta_bytes Amount of data in the database to actually backup.
+	templateMetrics := `# HELP pgbackrest_backup_delta_bytes Amount of data in the database to actually backup.
 # TYPE pgbackrest_backup_delta_bytes gauge
 pgbackrest_backup_delta_bytes{backup_name="20210607-092423F",backup_type="full",database_id="1",repo_key="1",stanza="demo"} 2.4316343e+07
 # HELP pgbackrest_backup_duration_seconds Backup duration.
@@ -69,8 +64,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetrics",
 			args{
-				"",
-				"",
 				templateStanza(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -120,7 +113,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 			mockData = tt.mockTestData
 			execCommand = fakeExecCommand
 			defer func() { execCommand = exec.Command }()
-			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -132,7 +125,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				pgbrStanzaBackupRepoBackupSizeMetric,
 				pgbrStanzaBackupRepoBackupSizeMapMetric,
 				pgbrStanzaBackupErrorMetric,
-				pgbrStanzaBackupDatabasesMetric,
 			)
 			metricFamily, err := reg.Gather()
 			if err != nil {
@@ -162,11 +154,8 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 // pgBackrest version < 2.44.
 //
 //nolint:dupl
-
 func TestGetRepoMapMetricsAbsent(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
@@ -205,8 +194,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetrics",
 			args{
-				"",
-				"",
 				templateStanzaRepoMapSizesAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -240,7 +227,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 			mockData = tt.mockTestData
 			execCommand = fakeExecCommand
 			defer func() { execCommand = exec.Command }()
-			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -250,7 +237,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 				pgbrStanzaBackupRepoBackupSetSizeMetric,
 				pgbrStanzaBackupRepoBackupSizeMetric,
 				pgbrStanzaBackupErrorMetric,
-				pgbrStanzaBackupDatabasesMetric,
 			)
 			metricFamily, err := reg.Gather()
 			if err != nil {
@@ -283,8 +269,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 //nolint:dupl
 func TestGetBackupMetricsDBsAbsent(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
@@ -323,8 +307,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetrics",
 			args{
-				"",
-				"",
 				templateStanzaRepoMapSizesAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -361,7 +343,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 			mockData = tt.mockTestData
 			execCommand = fakeExecCommand
 			defer func() { execCommand = exec.Command }()
-			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -408,8 +390,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 //nolint:dupl
 func TestGetBackupMetricsErrorAbsent(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
@@ -445,8 +425,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetricsErrorAbsent",
 			args{
-				"",
-				"",
 				templateStanzaErrorAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -477,7 +455,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 			mockData = tt.mockTestData
 			execCommand = fakeExecCommand
 			defer func() { execCommand = exec.Command }()
-			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -524,8 +502,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 //nolint:dupl
 func TestGetBackupMetricsRepoAbsent(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
@@ -561,8 +537,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 		{
 			"getBackupMetricsRepoAbsent",
 			args{
-				"",
-				"",
 				templateStanzaRepoAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -593,7 +567,7 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 			mockData = tt.mockTestData
 			execCommand = fakeExecCommand
 			defer func() { execCommand = exec.Command }()
-			testLastBackups := getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, logger)
+			testLastBackups := getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, logger)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
 				pgbrStanzaBackupInfoMetric,
@@ -626,8 +600,6 @@ pgbackrest_backup_size_bytes{backup_name="20210607-092423F",backup_type="full",d
 
 func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
 		stanzaName          string
 		backupData          []backup
 		dbData              []db
@@ -646,8 +618,6 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 		{
 			"getBackupMetricsLogError",
 			args{
-				"",
-				"",
 				templateStanza(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -671,8 +641,8 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 					100).DB,
 				true,
 				fakeSetUpMetricValue,
-				9,
-				9,
+				8,
+				8,
 			},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
@@ -696,8 +666,6 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 		{
 			"getBackupMetricsLogErrorWithRepo",
 			args{
-				"",
-				"",
 				templateStanzaRepoMapSizesAbsent(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -718,8 +686,8 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 					2969514).DB,
 				true,
 				fakeSetUpMetricValue,
-				8,
-				8,
+				7,
+				7,
 			},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
@@ -746,7 +714,7 @@ func TestGetBackupMetricsErrorsAndDebugs(t *testing.T) {
 			defer func() { execCommand = exec.Command }()
 			out := &bytes.Buffer{}
 			lc := log.NewLogfmtLogger(out)
-			getBackupMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.backupDBCount, tt.args.setUpMetricValueFun, lc)
+			getBackupMetrics(tt.args.stanzaName, tt.args.backupData, tt.args.dbData, tt.args.setUpMetricValueFun, lc)
 			errorsOutputCount := strings.Count(out.String(), "level=error")
 			debugsOutputCount := strings.Count(out.String(), "level=debug")
 			if tt.args.errorsCount != errorsOutputCount || tt.args.debugsCount != debugsOutputCount {

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -51,14 +51,15 @@ func TestSetPromPortAndPath(t *testing.T) {
 
 func TestGetPgBackRestInfo(t *testing.T) {
 	type args struct {
-		config              string
-		configIncludePath   string
-		backupType          string
-		stanzas             []string
-		stanzasExclude      []string
-		backupDBCount       bool
-		backupDBCountLatest bool
-		verboseWAL          bool
+		config                         string
+		configIncludePath              string
+		backupType                     string
+		stanzas                        []string
+		stanzasExclude                 []string
+		backupDBCount                  bool
+		backupDBCountLatest            bool
+		verboseWAL                     bool
+		backupDBCountParallelProcesses int
 	}
 	tests := []struct {
 		name         string
@@ -68,7 +69,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 	}{
 		{
 			"GetPgBackRestInfoGoodDataReturn",
-			args{"", "", "", []string{""}, []string{""}, true, true, false},
+			args{"", "", "", []string{""}, []string{""}, true, true, false, 1},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
@@ -86,7 +87,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			""},
 		{
 			"GetPgBackRestInfoGoodDataReturnWithWarn",
-			args{"", "", "", []string{""}, []string{""}, true, true, false},
+			args{"", "", "", []string{""}, []string{""}, true, true, false, 1},
 			mockStruct{
 				`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 					`"max":"000000010000000000000002","min":"000000010000000000000001"}],` +
@@ -104,7 +105,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="pgBackRest message" err="WARN: environment contains invalid option 'test'`},
 		{
 			"GetPgBackRestInfoBadDataReturn",
-			args{"", "", "", []string{""}, []string{""}, false, false, false},
+			args{"", "", "", []string{""}, []string{""}, false, false, false, 1},
 			mockStruct{
 				``,
 				`msg="pgBackRest message" err="ERROR: [029]: missing '=' in key/value at line 9: test"`,
@@ -113,7 +114,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="Get data from pgBackRest failed" err="exit status 29`},
 		{
 			"GetPgBackRestInfoZeroDataReturn",
-			args{"", "", "", []string{""}, []string{""}, false, false, false},
+			args{"", "", "", []string{""}, []string{""}, false, false, false, 1},
 			mockStruct{
 				`[]`,
 				``,
@@ -122,7 +123,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="No backup data returned"`},
 		{
 			"GetPgBackRestInfoJsonUnmarshalFail",
-			args{"", "", "", []string{""}, []string{""}, false, false, false},
+			args{"", "", "", []string{""}, []string{""}, false, false, false, 1},
 			mockStruct{
 				`[{}`,
 				``,
@@ -131,7 +132,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 			`msg="Parse JSON failed" err="unexpected end of JSON input"`},
 		{
 			"GetPgBackRestInfoEqualIncludeExcludeLists",
-			args{"", "", "", []string{"demo"}, []string{"demo"}, false, false, false},
+			args{"", "", "", []string{"demo"}, []string{"demo"}, false, false, false, 1},
 			mockStruct{
 				``,
 				``,
@@ -156,6 +157,7 @@ func TestGetPgBackRestInfo(t *testing.T) {
 				tt.args.backupDBCount,
 				tt.args.backupDBCountLatest,
 				tt.args.verboseWAL,
+				tt.args.backupDBCountParallelProcesses,
 				lc,
 			)
 			if !strings.Contains(out.String(), tt.testText) {

--- a/backrest/backrest_last_backup_metrics.go
+++ b/backrest/backrest_last_backup_metrics.go
@@ -1,9 +1,11 @@
 package backrest
 
 import (
+	"sync"
 	"time"
 
 	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -37,15 +39,7 @@ var (
 
 // Set backup metrics:
 //   - pgbackrest_backup_since_last_completion_seconds
-//   - pgbackrest_backup_last_databases
-func getBackupLastMetrics(config, configIncludePath, stanzaName string, lastBackups lastBackupsStruct, backupDBCountLatest bool, currentUnixTime int64, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
-	var (
-		err                     error
-		parseStanzaDataSpecific []stanza
-	)
-	lastBackups.full.backupType = "full"
-	lastBackups.diff.backupType = "diff"
-	lastBackups.incr.backupType = "incr"
+func getBackupLastMetrics(stanzaName string, lastBackups lastBackupsStruct, currentUnixTime int64, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
 	// If full backup exists, the values of metrics for differential and
 	// incremental backups also will be set.
 	// If not - metrics won't be set.
@@ -80,67 +74,93 @@ func getBackupLastMetrics(config, configIncludePath, stanzaName string, lastBack
 			lastBackups.incr.backupType,
 			stanzaName,
 		)
-		// If the calculation of the number of databases in latest backups is enabled.
-		// Information about number of databases in specific backup has appeared since pgBackRest v2.41.
-		// In versions < v2.41 this is missing and the metric does not need to be collected.
-		// getParsedSpecificBackupInfoData will return error in this case.
-		if backupDBCountLatest {
-			// Try to get info for full backup.
-			parseStanzaDataSpecific, err = getParsedSpecificBackupInfoData(config, configIncludePath, stanzaName, lastBackups.full.backupLabel, logger)
-			if err == nil {
-				// In a normal situation, only one element with one backup should be returned.
-				// If more than one element or one backup is returned, there is may be a bug in pgBackRest.
-				// If it's not a bug, then this part will need to be refactoring.
-				// Use *[]struct() type for backup.DatabaseRef.
-				if parseStanzaDataSpecific[0].Backup[0].DatabaseRef != nil {
-					// Number of databases in the last full backup.
-					setUpMetric(
-						pgbrStanzaBackupLastDatabasesMetric,
-						"pgbackrest_backup_last_databases",
-						float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
-						setUpMetricValueFun,
-						logger,
-						lastBackups.full.backupType,
-						stanzaName,
-					)
-				}
-			}
-			// If name for diff backup is equal to full, there is no point in re-receiving data.
-			if lastBackups.diff.backupLabel != lastBackups.full.backupLabel {
-				parseStanzaDataSpecific, err = getParsedSpecificBackupInfoData(config, configIncludePath, stanzaName, lastBackups.diff.backupLabel, logger)
-			}
-			if err == nil {
-				if parseStanzaDataSpecific[0].Backup[0].DatabaseRef != nil {
-					// Number of databases in the last full or differential backup.
-					setUpMetric(
-						pgbrStanzaBackupLastDatabasesMetric,
-						"pgbackrest_backup_last_databases",
-						float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
-						setUpMetricValueFun,
-						logger,
-						lastBackups.diff.backupType,
-						stanzaName,
-					)
-				}
-			}
-			// If name for incr backup is equal to diff, there is no point in re-receiving data.
-			if lastBackups.incr.backupLabel != lastBackups.diff.backupLabel {
-				parseStanzaDataSpecific, err = getParsedSpecificBackupInfoData(config, configIncludePath, stanzaName, lastBackups.incr.backupLabel, logger)
-			}
-			if err == nil {
-				if parseStanzaDataSpecific[0].Backup[0].DatabaseRef != nil {
-					// Number of databases in the last full, differential or incremental backup.
-					setUpMetric(
-						pgbrStanzaBackupLastDatabasesMetric,
-						"pgbackrest_backup_last_databases",
-						float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
-						setUpMetricValueFun,
-						logger,
-						lastBackups.incr.backupType,
-						stanzaName,
-					)
-				}
-			}
+	}
+}
+
+// Set backup metrics:
+//   - pgbackrest_backup_last_databases
+func getBackupLastDBCountMetrics(config, configIncludePath, stanzaName string, lastBackups lastBackupsStruct, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
+	// For diff and incr run in parallel.
+	var wg sync.WaitGroup
+	// If name for diff backup is equal to full, there is no point in re-receiving data.
+	if lastBackups.diff.backupLabel != lastBackups.full.backupLabel {
+		wg.Add(1)
+		go processSpecificBackupData(config, configIncludePath, stanzaName, lastBackups.diff.backupLabel, lastBackups.diff.backupType, setUpMetricValueFun, logger, &wg)
+	}
+	// If name for diff backup is equal to full, there is no point in re-receiving data.
+	if lastBackups.incr.backupLabel != lastBackups.diff.backupLabel {
+		wg.Add(1)
+		go processSpecificBackupData(config, configIncludePath, stanzaName, lastBackups.incr.backupLabel, lastBackups.incr.backupType, setUpMetricValueFun, logger, &wg)
+	}
+	// Try to get info for full backup.
+	parseStanzaDataSpecific, err := getParsedSpecificBackupInfoData(config, configIncludePath, stanzaName, lastBackups.full.backupLabel, logger)
+	if err != nil {
+		level.Error(logger).Log(
+			"msg", "Get data from pgBackRest failed",
+			"stanza", stanzaName,
+			"backup", lastBackups.full.backupLabel,
+			"err", err,
+		)
+	}
+	if checkBackupDatabaseRef(parseStanzaDataSpecific) {
+		// Number of databases in the last full backup.
+		setUpMetric(
+			pgbrStanzaBackupLastDatabasesMetric,
+			"pgbackrest_backup_last_databases",
+			float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
+			setUpMetricValueFun,
+			logger,
+			lastBackups.full.backupType,
+			stanzaName,
+		)
+		if lastBackups.diff.backupLabel == lastBackups.full.backupLabel {
+			setUpMetric(
+				pgbrStanzaBackupLastDatabasesMetric,
+				"pgbackrest_backup_last_databases",
+				float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
+				setUpMetricValueFun,
+				logger,
+				lastBackups.diff.backupType,
+				stanzaName,
+			)
+		}
+		if lastBackups.incr.backupLabel == lastBackups.diff.backupLabel {
+			setUpMetric(
+				pgbrStanzaBackupLastDatabasesMetric,
+				"pgbackrest_backup_last_databases",
+				float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
+				setUpMetricValueFun,
+				logger,
+				lastBackups.incr.backupType,
+				stanzaName,
+			)
+		}
+	}
+}
+
+func processSpecificBackupData(config, configIncludePath, stanzaName, backupLabel, backupType string, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger, wg *sync.WaitGroup) {
+	defer wg.Done()
+	parseStanzaDataSpecific, err := getParsedSpecificBackupInfoData(config, configIncludePath, stanzaName, backupLabel, logger)
+	if err != nil {
+		level.Error(logger).Log(
+			"msg", "Get data from pgBackRest failed",
+			"stanza", stanzaName,
+			"backup", backupLabel,
+			"err", err,
+		)
+	}
+	if err == nil {
+		if checkBackupDatabaseRef(parseStanzaDataSpecific) {
+			// Number of databases in the last differential or incremental backup.
+			setUpMetric(
+				pgbrStanzaBackupLastDatabasesMetric,
+				"pgbackrest_backup_last_databases",
+				float64(len(*parseStanzaDataSpecific[0].Backup[0].DatabaseRef)),
+				setUpMetricValueFun,
+				logger,
+				backupType,
+				stanzaName,
+			)
 		}
 	}
 }

--- a/backrest/backrest_last_backup_metrics_test.go
+++ b/backrest/backrest_last_backup_metrics_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -41,9 +40,8 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="full",stanza="demo"
 pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"} 9.223372036854776e+09
 `
 	tests := []struct {
-		name                   string
-		args                   args
-		mockTestDataBackupLast mockBackupLastStruct
+		name string
+		args args
 	}{
 		{
 			"getBackupLastMetrics",
@@ -56,6 +54,72 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 					12,
 					100).Name,
 				templateLastBackupDifferent(),
+				currentUnixTimeForTests,
+				setUpMetricValue,
+				templateMetrics,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetMetrics()
+			getBackupLastMetrics(tt.args.stanzaName, tt.args.lastBackups, tt.args.currentUnixTime, tt.args.setUpMetricValueFun, logger)
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(pgbrStanzaBackupSinceLastCompletionSecondsMetric)
+			metricFamily, err := reg.Gather()
+			if err != nil {
+				fmt.Println(err)
+			}
+			out := &bytes.Buffer{}
+			for _, mf := range metricFamily {
+				if _, err := expfmt.MetricFamilyToText(out, mf); err != nil {
+					panic(err)
+				}
+			}
+			if tt.args.testText != out.String() {
+				t.Errorf(
+					"\nVariables do not match, metrics:\n%s\nwant:\n%s", tt.args.testText, out.String())
+			}
+		})
+	}
+}
+
+// All metrics exist and all labels are corrected.
+// pgBackrest version = latest.
+func TestGetBackupLastDBCountMetrics(t *testing.T) {
+	type args struct {
+		config              string
+		configIncludePath   string
+		stanzaName          string
+		lastBackups         lastBackupsStruct
+		currentUnixTime     int64
+		setUpMetricValueFun setUpMetricValueFunType
+		testText            string
+	}
+	templateMetrics := `# HELP pgbackrest_backup_last_databases Number of databases in the last full, differential or incremental backup.
+# TYPE pgbackrest_backup_last_databases gauge
+pgbackrest_backup_last_databases{backup_type="diff",stanza="demo"} 1
+pgbackrest_backup_last_databases{backup_type="full",stanza="demo"} 1
+pgbackrest_backup_last_databases{backup_type="incr",stanza="demo"} 1
+`
+	tests := []struct {
+		name                   string
+		args                   args
+		mockTestDataBackupLast mockBackupLastStruct
+	}{
+		{
+			"getBackupLastMetricsSame",
+			args{
+				"",
+				"",
+				templateStanza(
+					"000000010000000000000004",
+					"000000010000000000000001",
+					[]databaseRef{{"postgres", 13425}},
+					true,
+					12,
+					100).Name,
+				templateLastBackup(),
 				currentUnixTimeForTests,
 				setUpMetricValue,
 				templateMetrics,
@@ -79,12 +143,12 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 				mockStruct{
 					`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 						`"max":"000000010000000000000010","min":"000000010000000000000001"}],` +
-						`"backup":[{"archive":{"start":"000000010000000000000005","stop":"000000010000000000000006"},` +
-						`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":2},` +
-						`"database-ref":[{"name":"postgres","oid":13412},{"name":"test_db","oid":16384}],` +
-						`"error":false,"info":{"delta":16657,"repository":{"delta":518,"size":3970802},"size":32230338},` +
-						`"label":"20220926-201857F_20220926-201901D","link":null,"lsn":{"start":"0/5000028","stop":"0/6000050"},"prior":"20220926-201857F",` +
-						`"reference":["20220926-201857F"],"tablespace":null,"timestamp":{"start":1664223541,"stop":1664223543},"type":"diff"}],` +
+						`"backup":[{"archive":{"start":"000000010000000000000003","stop":"000000010000000000000004"},` +
+						`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":1},` +
+						`"database-ref":[{"name":"postgres","oid":13412}],"error":false,` +
+						`"info":{"delta":32230330,"repository":{"delta":3970793,"size":3970793},"size":32230330},` +
+						`"label":"20220926-201857F","link":null,"lsn":{"start":"0/3000028","stop":"0/4000050"},"prior":null,` +
+						`"reference":null,"tablespace":null,"timestamp":{"start":1664223537,"stop":1664223540},"type":"full"}],` +
 						`"cipher":"none","db":[{"id":1,"repo-key":1,"system-id":7147741414128675215,"version":"13"}],` +
 						`"name":"demo","repo":[{"cipher":"none","key":1,"status":{"code":0,"message":"ok"}}],` +
 						`"status":{"code":0,"lock":{"backup":{"held":false}},"message":"ok"}}]`,
@@ -94,13 +158,12 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 				mockStruct{
 					`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
 						`"max":"000000010000000000000010","min":"000000010000000000000001"}],` +
-						`"backup":[{"archive":{"start":"000000010000000000000008","stop":"000000010000000000000008"},` +
+						`"backup":[{"archive":{"start":"000000010000000000000003","stop":"000000010000000000000004"},` +
 						`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":1},` +
-						`"database-ref":[{"name":"postgres","oid":13412},{"name":"test_db","oid":16384}],` +
-						`"error":false,"info":{"delta":16657,"repository":{"delta":519,"size":3970803},"size":32230338},` +
-						`"label":"20220926-201854F_20220926-202454I","link":null,"lsn":{"start":"0/8000028","stop":"0/8000138"},` +
-						`"prior":"20220926-201854F","reference":["20220926-201854F"],"tablespace":null,` +
-						`"timestamp":{"start":1664223894,"stop":1664223896},"type":"incr"}],` +
+						`"database-ref":[{"name":"postgres","oid":13412}],"error":false,` +
+						`"info":{"delta":32230330,"repository":{"delta":3970793,"size":3970793},"size":32230330},` +
+						`"label":"20220926-201857F","link":null,"lsn":{"start":"0/3000028","stop":"0/4000050"},"prior":null,` +
+						`"reference":null,"tablespace":null,"timestamp":{"start":1664223537,"stop":1664223540},"type":"full"}],` +
 						`"cipher":"none","db":[{"id":1,"repo-key":1,"system-id":7147741414128675215,"version":"13"}],` +
 						`"name":"demo","repo":[{"cipher":"none","key":1,"status":{"code":0,"message":"ok"}}],` +
 						`"status":{"code":0,"lock":{"backup":{"held":false}},"message":"ok"}}]`,
@@ -117,10 +180,9 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 			execCommand = fakeExecCommandSpecificDatabase
 			defer func() { execCommand = exec.Command }()
 			lc := log.NewNopLogger()
-			getBackupLastMetrics(tt.args.stanzaName, tt.args.lastBackups, tt.args.currentUnixTime, tt.args.setUpMetricValueFun, lc)
+			getBackupLastDBCountMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.lastBackups, tt.args.setUpMetricValueFun, lc)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
-				pgbrStanzaBackupSinceLastCompletionSecondsMetric,
 				pgbrStanzaBackupLastDatabasesMetric,
 			)
 			metricFamily, err := reg.Gather()
@@ -145,20 +207,17 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 //   - pgbackrest_backup_last_databases.
 //
 // pgBackrest version < v2.41.
-func TestGetBackupLastMetricsDBsAbsent(t *testing.T) {
+func TestGetBackupLastDBCountMetricsDBsAbsent(t *testing.T) {
 	type args struct {
+		config              string
+		configIncludePath   string
 		stanzaName          string
 		lastBackups         lastBackupsStruct
 		currentUnixTime     int64
 		setUpMetricValueFun setUpMetricValueFunType
 		testText            string
 	}
-	templateMetrics := `# HELP pgbackrest_backup_since_last_completion_seconds Seconds since the last completed full, differential or incremental backup.
-# TYPE pgbackrest_backup_since_last_completion_seconds gauge
-pgbackrest_backup_since_last_completion_seconds{backup_type="diff",stanza="demo"} 9.223372036854776e+09
-pgbackrest_backup_since_last_completion_seconds{backup_type="full",stanza="demo"} 9.223372036854776e+09
-pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"} 9.223372036854776e+09
-`
+	templateMetrics := ``
 	tests := []struct {
 		name                   string
 		args                   args
@@ -167,6 +226,8 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 		{
 			"getBackupLastMetrics",
 			args{
+				"",
+				"",
 				templateStanza(
 					"000000010000000000000004",
 					"000000010000000000000001",
@@ -205,10 +266,10 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 			execCommand = fakeExecCommandSpecificDatabase
 			defer func() { execCommand = exec.Command }()
 			lc := log.NewNopLogger()
-			getBackupLastMetrics(tt.args.stanzaName, tt.args.lastBackups, tt.args.currentUnixTime, tt.args.setUpMetricValueFun, lc)
+			getBackupLastDBCountMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.lastBackups, tt.args.setUpMetricValueFun, lc)
 			reg := prometheus.NewRegistry()
 			reg.MustRegister(
-				pgbrStanzaBackupSinceLastCompletionSecondsMetric,
+				pgbrStanzaBackupLastDatabasesMetric,
 			)
 			metricFamily, err := reg.Gather()
 			if err != nil {
@@ -228,105 +289,6 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 	}
 }
 
-func TestGetBackupLastMetricsErrorsAndDebugs(t *testing.T) {
-	type args struct {
-		stanzaName          string
-		lastBackups         lastBackupsStruct
-		currentUnixTime     int64
-		setUpMetricValueFun setUpMetricValueFunType
-		errorsCount         int
-		debugsCount         int
-	}
-	tests := []struct {
-		name                   string
-		args                   args
-		mockTestDataBackupLast mockBackupLastStruct
-	}{
-		{
-			"getBackupLastMetricsLogError",
-			args{
-				templateStanza(
-					"000000010000000000000004",
-					"000000010000000000000001",
-					[]databaseRef{{"postgres", 13425}},
-					true,
-					12,
-					100).Name,
-				templateLastBackup(),
-				currentUnixTimeForTests,
-				fakeSetUpMetricValue,
-				3,
-				3,
-			},
-			mockBackupLastStruct{
-				mockStruct{
-					`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
-						`"max":"000000010000000000000010","min":"000000010000000000000001"}],` +
-						`"backup":[{"archive":{"start":"000000010000000000000003","stop":"000000010000000000000004"},` +
-						`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":1},` +
-						`"database-ref":[{"name":"postgres","oid":13412}],"error":false,` +
-						`"info":{"delta":32230330,"repository":{"delta":3970793,"size":3970793},"size":32230330},` +
-						`"label":"20220926-201857F","link":null,"lsn":{"start":"0/3000028","stop":"0/4000050"},"prior":null,` +
-						`"reference":null,"tablespace":null,"timestamp":{"start":1664223537,"stop":1664223540},"type":"full"}],` +
-						`"cipher":"none","db":[{"id":1,"repo-key":1,"system-id":7147741414128675215,"version":"13"}],` +
-						`"name":"demo","repo":[{"cipher":"none","key":1,"status":{"code":0,"message":"ok"}}],` +
-						`"status":{"code":0,"lock":{"backup":{"held":false}},"message":"ok"}}]`,
-					"",
-					0,
-				},
-				mockStruct{
-					`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
-						`"max":"000000010000000000000010","min":"000000010000000000000001"}],` +
-						`"backup":[{"archive":{"start":"000000010000000000000005","stop":"000000010000000000000006"},` +
-						`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":2},` +
-						`"database-ref":[{"name":"postgres","oid":13412},{"name":"test_db","oid":16384}],` +
-						`"error":false,"info":{"delta":16657,"repository":{"delta":518,"size":3970802},"size":32230338},` +
-						`"label":"20220926-201857F_20220926-201901D","link":null,"lsn":{"start":"0/5000028","stop":"0/6000050"},"prior":"20220926-201857F",` +
-						`"reference":["20220926-201857F"],"tablespace":null,"timestamp":{"start":1664223541,"stop":1664223543},"type":"diff"}],` +
-						`"cipher":"none","db":[{"id":1,"repo-key":1,"system-id":7147741414128675215,"version":"13"}],` +
-						`"name":"demo","repo":[{"cipher":"none","key":1,"status":{"code":0,"message":"ok"}}],` +
-						`"status":{"code":0,"lock":{"backup":{"held":false}},"message":"ok"}}]`,
-					"",
-					0,
-				},
-				mockStruct{
-					`[{"archive":[{"database":{"id":1,"repo-key":1},"id":"13-1",` +
-						`"max":"000000010000000000000010","min":"000000010000000000000001"}],` +
-						`"backup":[{"archive":{"start":"000000010000000000000008","stop":"000000010000000000000008"},` +
-						`"backrest":{"format":5,"version":"2.41"},"database":{"id":1,"repo-key":1},` +
-						`"database-ref":[{"name":"postgres","oid":13412},{"name":"test_db","oid":16384}],` +
-						`"error":false,"info":{"delta":16657,"repository":{"delta":519,"size":3970803},"size":32230338},` +
-						`"label":"20220926-201854F_20220926-202454I","link":null,"lsn":{"start":"0/8000028","stop":"0/8000138"},` +
-						`"prior":"20220926-201854F","reference":["20220926-201854F"],"tablespace":null,` +
-						`"timestamp":{"start":1664223894,"stop":1664223896},"type":"incr"}],` +
-						`"cipher":"none","db":[{"id":1,"repo-key":1,"system-id":7147741414128675215,"version":"13"}],` +
-						`"name":"demo","repo":[{"cipher":"none","key":1,"status":{"code":0,"message":"ok"}}],` +
-						`"status":{"code":0,"lock":{"backup":{"held":false}},"message":"ok"}}]`,
-					"",
-					0,
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockDataBackupLast = tt.mockTestDataBackupLast
-			execCommand = fakeExecCommandSpecificDatabase
-			defer func() { execCommand = exec.Command }()
-			out := &bytes.Buffer{}
-			lc := log.NewLogfmtLogger(out)
-			getBackupLastMetrics(tt.args.stanzaName, tt.args.lastBackups, tt.args.currentUnixTime, tt.args.setUpMetricValueFun, lc)
-			errorsOutputCount := strings.Count(out.String(), "level=error")
-			debugsOutputCount := strings.Count(out.String(), "level=debug")
-			if tt.args.errorsCount != errorsOutputCount || tt.args.debugsCount != debugsOutputCount {
-				t.Errorf("\nVariables do not match:\nerrors=%d, debugs=%d\nwant:\nerrors=%d, debugs=%d",
-					tt.args.errorsCount, tt.args.debugsCount,
-					errorsOutputCount, debugsOutputCount)
-			}
-		})
-	}
-}
-
 //nolint:unparam
 func templateLastBackup() lastBackupsStruct {
 	return lastBackupsStruct{
@@ -341,6 +303,6 @@ func templateLastBackupDifferent() lastBackupsStruct {
 	return lastBackupsStruct{
 		backupStruct{"20220926-201857F", "full", time.Unix(1623706322, 0)},
 		backupStruct{"20220926-201857F_20220926-201901D", "diff", time.Unix(1623706322, 0)},
-		backupStruct{"20220926-201854F_20220926-202454I", "incr", time.Unix(1623706322, 0)},
+		backupStruct{"20220926-201857F_20220926-202454I", "incr", time.Unix(1623706322, 0)},
 	}
 }

--- a/backrest/backrest_last_backup_metrics_test.go
+++ b/backrest/backrest_last_backup_metrics_test.go
@@ -84,8 +84,6 @@ pgbackrest_backup_since_last_completion_seconds{backup_type="incr",stanza="demo"
 	}
 }
 
-// All metrics exist and all labels are corrected.
-// pgBackrest version = latest.
 func TestGetBackupLastDBCountMetrics(t *testing.T) {
 	type args struct {
 		config              string
@@ -107,6 +105,8 @@ pgbackrest_backup_last_databases{backup_type="incr",stanza="demo"} 1
 		args                   args
 		mockTestDataBackupLast mockBackupLastStruct
 	}{
+		// All metrics exist and all labels are corrected.
+		// pgBackrest version = latest.
 		{
 			"getBackupLastMetricsSame",
 			args{
@@ -172,59 +172,12 @@ pgbackrest_backup_last_databases{backup_type="incr",stanza="demo"} 1
 				},
 			},
 		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resetMetrics()
-			mockDataBackupLast = tt.mockTestDataBackupLast
-			execCommand = fakeExecCommandSpecificDatabase
-			defer func() { execCommand = exec.Command }()
-			lc := log.NewNopLogger()
-			getBackupLastDBCountMetrics(tt.args.config, tt.args.configIncludePath, tt.args.stanzaName, tt.args.lastBackups, tt.args.setUpMetricValueFun, lc)
-			reg := prometheus.NewRegistry()
-			reg.MustRegister(
-				pgbrStanzaBackupLastDatabasesMetric,
-			)
-			metricFamily, err := reg.Gather()
-			if err != nil {
-				fmt.Println(err)
-			}
-			out := &bytes.Buffer{}
-			for _, mf := range metricFamily {
-				if _, err := expfmt.MetricFamilyToText(out, mf); err != nil {
-					panic(err)
-				}
-			}
-			if tt.args.testText != out.String() {
-				t.Errorf(
-					"\nVariables do not match, metrics:\n%s\nwant:\n%s", tt.args.testText, out.String())
-			}
-		})
-	}
-}
-
-// Absent metrics:
-//   - pgbackrest_backup_last_databases.
-//
-// pgBackrest version < v2.41.
-func TestGetBackupLastDBCountMetricsDBsAbsent(t *testing.T) {
-	type args struct {
-		config              string
-		configIncludePath   string
-		stanzaName          string
-		lastBackups         lastBackupsStruct
-		currentUnixTime     int64
-		setUpMetricValueFun setUpMetricValueFunType
-		testText            string
-	}
-	templateMetrics := ``
-	tests := []struct {
-		name                   string
-		args                   args
-		mockTestDataBackupLast mockBackupLastStruct
-	}{
+		// Absent metrics:
+		//   - pgbackrest_backup_last_databases.
+		//
+		// pgBackrest version < v2.41.
 		{
-			"getBackupLastMetrics",
+			"getBackupLastMetricsDatabasesAbsent",
 			args{
 				"",
 				"",
@@ -238,7 +191,7 @@ func TestGetBackupLastDBCountMetricsDBsAbsent(t *testing.T) {
 				templateLastBackupDifferent(),
 				currentUnixTimeForTests,
 				setUpMetricValue,
-				templateMetrics,
+				``,
 			},
 			mockBackupLastStruct{
 				mockStruct{

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -28,8 +28,13 @@ type lastBackupsStruct struct {
 
 var execCommand = exec.Command
 
-// https://golang.org/pkg/time/#Time.Format
-const layout = "2006-01-02 15:04:05"
+const (
+	// https://golang.org/pkg/time/#Time.Format
+	layout    = "2006-01-02 15:04:05"
+	fullLabel = "full"
+	diffLabel = "diff"
+	incrLabel = "incr"
+)
 
 func returnDefaultExecArgs() []string {
 	// Base exec arguments.
@@ -276,4 +281,16 @@ func resetMetrics() {
 	resetBackupMetrics()
 	resetLastBackupMetrics()
 	resetWALMetrics()
+}
+
+func checkBackupDatabaseRef(backupData []stanza) bool {
+	// In a normal situation, only one element with one backup should be returned.
+	// If more than one element or one backup is returned, there is may be a bug in pgBackRest.
+	// If it's not a bug, then this part will need to be refactoring.
+	// Use *[]struct() type for backup.DatabaseRef.
+	if (len(backupData) != 0 && len(backupData[0].Backup) != 0) &&
+		backupData[0].Backup[0].DatabaseRef != nil {
+		return true
+	}
+	return false
 }

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -695,24 +695,6 @@ func TestConvertBoolToFloat64(t *testing.T) {
 	}
 }
 
-//nolint:unparam
-func templateLastBackup() lastBackupsStruct {
-	return lastBackupsStruct{
-		backupStruct{"20210607-092423F", "", time.Unix(1623706322, 0)},
-		backupStruct{"20210607-092423F", "", time.Unix(1623706322, 0)},
-		backupStruct{"20210607-092423F", "", time.Unix(1623706322, 0)},
-	}
-}
-
-//nolint:unparam
-func templateLastBackupDifferent() lastBackupsStruct {
-	return lastBackupsStruct{
-		backupStruct{"20220926-201857F", "", time.Unix(1623706322, 0)},
-		backupStruct{"20220926-201857F_20220926-201901D", "", time.Unix(1623706322, 0)},
-		backupStruct{"20220926-201854F_20220926-202454I", "", time.Unix(1623706322, 0)},
-	}
-}
-
 func TestGetParsedSpecificBackupInfoDataErrors(t *testing.T) {
 	type args struct {
 		config            string

--- a/backrest/backrest_parser_test.go
+++ b/backrest/backrest_parser_test.go
@@ -795,3 +795,49 @@ func checkBackupType(a []string, regex string) bool {
 	}
 	return false
 }
+
+func TestCheckBackupDatabaseRef(t *testing.T) {
+	type args struct{ backupData []stanza }
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Empty backupData",
+			args: struct{ backupData []stanza }{
+				backupData: []stanza{},
+			},
+			want: false,
+		},
+		{
+			name: "Empty backup",
+			args: struct{ backupData []stanza }{
+				backupData: []stanza{{Backup: []backup{}}},
+			},
+			want: false,
+		},
+		{
+			name: "Nil DatabaseRef",
+			args: struct{ backupData []stanza }{
+				backupData: []stanza{{Backup: []backup{{DatabaseRef: nil}}}},
+			},
+			want: false,
+		},
+		{
+			name: "Non-nil DatabaseRef",
+			args: struct{ backupData []stanza }{
+				backupData: []stanza{{Backup: []backup{{DatabaseRef: &[]databaseRef{{"postgres", 13425}}}}}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := checkBackupDatabaseRef(tt.args.backupData); got != tt.want {
+				t.Errorf("\nVariables do not match:\n%v\nwant:\n%v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -54,6 +54,10 @@ func main() {
 			"backrest.database-count",
 			"Exposing the number of databases in backups.",
 		).Default("false").Bool()
+		backrestBackupDBCountParallelProcesses = kingpin.Flag(
+			"backrest.database-parallel-processes",
+			"Number of parallel processes for collecting information about databases.",
+		).Default("1").Int()
 		backrestBackupDBCountLatest = kingpin.Flag(
 			"backrest.database-count-latest",
 			"Exposing the number of databases in the latest backups.",
@@ -123,7 +127,8 @@ func main() {
 	if *backrestBackupDBCount {
 		level.Info(logger).Log(
 			"msg", "Exposing the number of databases in backups",
-			"database-count", *backrestBackupDBCount)
+			"database-count", *backrestBackupDBCount,
+			"database-parallel-processes", *backrestBackupDBCountParallelProcesses)
 	}
 	if *backrestBackupDBCountLatest {
 		level.Info(logger).Log(
@@ -159,6 +164,7 @@ func main() {
 			*backrestBackupDBCount,
 			*backrestBackupDBCountLatest,
 			*backrestVerboseWAL,
+			*backrestBackupDBCountParallelProcesses,
 			logger,
 		)
 		// Sleep for 'collection.interval' seconds.


### PR DESCRIPTION
Moved collection of `*_databases` metrics into separate functions.
Added parallelization for collecting `*_databases` metrics.
Added `--backrest.database-parallel-processes` flag - number of parallel processes for collecting information about databases.
Fixed bug with exporter crashing  for `*_databases`  metrics when stanza no contains backups in pgBackRest output for specific backup.