### PR TITLE
Add new `*_last_*` metrics.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV EXPORTER_ENDPOINT="/metrics" \
     BACKUP_TYPE="" \
     VERBOSE_WAL="false" \
     DATABASE_COUNT="false" \
+    DATABASE_PARALLEL_PROCESSES="1" \
     DATABASE_COUNT_LATEST="false"
 COPY --chmod=755 docker_files/run_exporter.sh /run_exporter.sh
 COPY --from=builder --chmod=755 /build/pgbackrest_exporter /etc/pgbackrest/pgbackrest_exporter

--- a/README.md
+++ b/README.md
@@ -85,6 +85,38 @@ The metrics provided by the client.
 
     Labels: backup_type, stanza.
 
+* `pgbackrest_backup_last_duration_seconds` - backup duration for the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_size_bytes` - full uncompressed size of the database in the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_delta_bytes` - amount of data in the database to actually backup in the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_repo_size_bytes` - full compressed files size to restore the database from the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_repo_delta_bytes` - compressed files size in the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_repo_size_map_bytes` - size of block incremental map in the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_repo_delta_map_bytes` - size of block incremental delta map in the last full, differential or incremental backup.
+
+    Labels: backup_type, stanza.
+
+* `pgbackrest_backup_last_error_status` - error status in the last full, differential or incremental backup
+
+    Labels: backup_type, stanza.
+
 * `pgbackrest_wal_archive_status` - current WAL archive status.
 
     Labels: database_id, pg_version, repo_key, stanza, wal_max, wal_min.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Flags:
       --backrest.backup-type=""  Specific backup type for collecting metrics. One of: [full, incr, diff].
       --[no-]backrest.database-count  
                                  Exposing the number of databases in backups.
+      --backrest.database-parallel-processes=1  
+                                 Number of parallel processes for collecting information about databases.
       --[no-]backrest.database-count-latest  
                                  Exposing the number of databases in the latest backups.
       --[no-]backrest.verbose-wal  
@@ -244,6 +246,9 @@ When flag `--backrest.database-count` is specified - information about the numbe
 This flag works for `pgBackRest >= v2.41`.<br>
 For earlier pgBackRest versions there will be an error like: `option 'set' is currently only valid for text output`.<br>
 For a significant numbers of stanzas and backups, this may require much more additional time to collect metrics. Each stanza requires pgBackRest execution for backups to get data.
+
+The flag `--backrest.database-parallel-processes` allows to increase the number of parallel processes for collecting information about databases in backups.<br>
+This flag is valid only when the flag `--backrest.database-count` is specified.
 
 When flag `--backrest.database-count-latest` is specified - information about the number of databases in the last full, differential or incremental backup is collected.<br>
 This flag works for `pgBackRest >= v2.41`.<br>

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Environment variables supported by this image:
 * `BACKUP_TYPE` - specific backup type for collecting metrics, default `""`;
 * `VERBOSE_WAL` - enabling additional labels for WAL metrics, default `false`;
 * `DATABASE_COUNT` - exposing the number of databases in backups, default `false`;
+* `DATABASE_PARALLEL_PROCESSES` - number of parallel processes for collecting information about databases in backups, default `1`;
 * `DATABASE_COUNT_LATEST` - exposing the number of databases in the latest backups, default `false`.
 
 #### Pull

--- a/backrest/backrest_backup_metrics.go
+++ b/backrest/backrest_backup_metrics.go
@@ -332,12 +332,7 @@ func getBackupMetrics(stanzaName string, backupData []backup, dbData []db, setUp
 				stanzaName,
 			)
 		}
-		compareLastBackups(
-			&lastBackups,
-			time.Unix(backup.Timestamp.Stop, 0),
-			backup.Label,
-			backup.Type,
-		)
+		compareLastBackups(&lastBackups, backup)
 	}
 	return lastBackups
 }

--- a/backrest/backrest_exporter_test.go
+++ b/backrest/backrest_exporter_test.go
@@ -209,3 +209,7 @@ func getLogger() log.Logger {
 func ptrToVal[T any](v *T) T {
 	return *v
 }
+
+func valToPtr[T any](v T) *T {
+	return &v
+}

--- a/backrest/backrest_last_backup_metrics.go
+++ b/backrest/backrest_last_backup_metrics.go
@@ -80,14 +80,14 @@ var (
 			"stanza"})
 	pgbrStanzaBackupLastRepoBackupSizeMapMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pgbackrest_backup_last_repo_delta_map_bytes",
-		Help: "Size of block incremental delta map in the last full, differential or incremental backup..",
+		Help: "Size of block incremental delta map in the last full, differential or incremental backup.",
 	},
 		[]string{
 			"backup_type",
 			"stanza"})
 	pgbrStanzaBackupLastErrorMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pgbackrest_backup_last_error_status",
-		Help: "Backup error status.",
+		Help: "Error status in the last full, differential or incremental backup.",
 	},
 		[]string{
 			"backup_type",

--- a/backrest/backrest_last_backup_metrics.go
+++ b/backrest/backrest_last_backup_metrics.go
@@ -35,45 +35,178 @@ var (
 		[]string{
 			"backup_type",
 			"stanza"})
+	pgbrStanzaBackupLastDurationMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_duration_seconds",
+		Help: "Backup duration for the last full, differential or incremental backup.",
+	},
+		[]string{
+			"backup_type",
+			"stanza",
+		})
+	pgbrStanzaBackupLastDatabaseSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_size_bytes",
+		Help: "Full uncompressed size of the database in the last full, differential or incremental backup.",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
+	pgbrStanzaBackupLastDatabaseBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_delta_bytes",
+		Help: "Amount of data in the database to actually backup in the last full, differential or incremental backup.",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
+	pgbrStanzaBackupLastRepoBackupSetSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_repo_size_bytes",
+		Help: "Full compressed files size to restore the database from the last full, differential or incremental backup.",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
+	pgbrStanzaBackupLastRepoBackupSetSizeMapMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_repo_size_map_bytes",
+		Help: "Size of block incremental map in the last full, differential or incremental backup.",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
+	pgbrStanzaBackupLastRepoBackupSizeMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_repo_delta_bytes",
+		Help: "Compressed files size in the last full, differential or incremental backup.",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
+	pgbrStanzaBackupLastRepoBackupSizeMapMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_repo_delta_map_bytes",
+		Help: "Size of block incremental delta map in the last full, differential or incremental backup..",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
+	pgbrStanzaBackupLastErrorMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_backup_last_error_status",
+		Help: "Backup error status.",
+	},
+		[]string{
+			"backup_type",
+			"stanza"})
 )
 
 // Set backup metrics:
 //   - pgbackrest_backup_since_last_completion_seconds
+//   - pgbackrest_backup_last_duration_seconds
+//   - pgbackrest_backup_last_size_bytes
+//   - pgbackrest_backup_last_delta_bytes
+//   - pgbackrest_backup_last_repo_size_bytes
+//   - pgbackrest_backup_last_repo_size_map_bytes
+//   - pgbackrest_backup_last_repo_delta_bytes
+//   - pgbackrest_backup_last_repo_delta_map_bytes
+//   - pgbackrest_backup_last_error_status
 func getBackupLastMetrics(stanzaName string, lastBackups lastBackupsStruct, currentUnixTime int64, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
 	// If full backup exists, the values of metrics for differential and
 	// incremental backups also will be set.
 	// If not - metrics won't be set.
 	if !lastBackups.full.backupTime.IsZero() {
-		// Seconds since the last completed full backup.
-		setUpMetric(
-			pgbrStanzaBackupSinceLastCompletionSecondsMetric,
-			"pgbackrest_backup_since_last_completion_seconds",
-			time.Unix(currentUnixTime, 0).Sub(lastBackups.full.backupTime).Seconds(),
-			setUpMetricValueFun,
-			logger,
-			lastBackups.full.backupType,
-			stanzaName,
-		)
-		// Seconds since the last completed full or differential backup.
-		setUpMetric(
-			pgbrStanzaBackupSinceLastCompletionSecondsMetric,
-			"pgbackrest_backup_since_last_completion_seconds",
-			time.Unix(currentUnixTime, 0).Sub(lastBackups.diff.backupTime).Seconds(),
-			setUpMetricValueFun,
-			logger,
-			lastBackups.diff.backupType,
-			stanzaName,
-		)
-		// Seconds since the last completed full, differential or incremental backup.
-		setUpMetric(
-			pgbrStanzaBackupSinceLastCompletionSecondsMetric,
-			"pgbackrest_backup_since_last_completion_seconds",
-			time.Unix(currentUnixTime, 0).Sub(lastBackups.incr.backupTime).Seconds(),
-			setUpMetricValueFun,
-			logger,
-			lastBackups.incr.backupType,
-			stanzaName,
-		)
+		for _, backup := range []backupStruct{lastBackups.full, lastBackups.diff, lastBackups.incr} {
+			if backup.backupRepoSizeMap != nil && backup.backupRepoDeltaMap != nil {
+				// Repo backup map size for last backups.
+				setUpMetric(
+					pgbrStanzaBackupLastRepoBackupSetSizeMapMetric,
+					"pgbackrest_backup_last_repo_size_map_bytes",
+					float64(*backup.backupRepoSizeMap),
+					setUpMetricValueFun,
+					logger,
+					backup.backupType,
+					stanzaName,
+				)
+				// Repo backup delta map size for last backups.
+				setUpMetric(
+					pgbrStanzaBackupLastRepoBackupSizeMapMetric,
+					"pgbackrest_backup_last_repo_delta_map_bytes",
+					float64(*backup.backupRepoDeltaMap),
+					setUpMetricValueFun,
+					logger,
+					backup.backupType,
+					stanzaName,
+				)
+			}
+			// Seconds since the last completed backups.
+			setUpMetric(
+				pgbrStanzaBackupSinceLastCompletionSecondsMetric,
+				"pgbackrest_backup_since_last_completion_seconds",
+				time.Unix(currentUnixTime, 0).Sub(backup.backupTime).Seconds(),
+				setUpMetricValueFun,
+				logger,
+				backup.backupType,
+				stanzaName,
+			)
+			// Backup durations in seconds for last backups.
+			setUpMetric(
+				pgbrStanzaBackupLastDurationMetric,
+				"pgbackrest_backup_last_duration_seconds",
+				backup.backupDuration,
+				setUpMetricValueFun,
+				logger,
+				backup.backupType,
+				stanzaName,
+			)
+			// Database size for last backups.
+			setUpMetric(
+				pgbrStanzaBackupLastDatabaseSizeMetric,
+				"pgbackrest_backup_last_size_bytes",
+				float64(backup.backupSize),
+				setUpMetricValueFun,
+				logger,
+				backup.backupType,
+				stanzaName,
+			)
+			// Database backup size for last backups.
+			setUpMetric(
+				pgbrStanzaBackupLastDatabaseBackupSizeMetric,
+				"pgbackrest_backup_last_delta_bytes",
+				float64(backup.backupDelta),
+				setUpMetricValueFun,
+				logger,
+				backup.backupType,
+				stanzaName,
+			)
+			// Repo backup set size.
+			if backup.backupRepoSize != nil {
+				setUpMetric(
+					pgbrStanzaBackupLastRepoBackupSetSizeMetric,
+					"pgbackrest_backup_last_repo_size_bytes",
+					float64(*backup.backupRepoSize),
+					setUpMetricValueFun,
+					logger,
+					backup.backupType,
+					stanzaName,
+				)
+			}
+			// Repo backup size.
+			setUpMetric(
+				pgbrStanzaBackupLastRepoBackupSizeMetric,
+				"pgbackrest_backup_last_repo_delta_bytes",
+				float64(backup.backupRepoDelta),
+				setUpMetricValueFun,
+				logger,
+				backup.backupType,
+				stanzaName,
+			)
+			// Backup error status.
+			if backup.backupError != nil {
+				setUpMetric(
+					pgbrStanzaBackupLastErrorMetric,
+					"pgbackrest_backup_last_error_status",
+					convertBoolToFloat64(*backup.backupError),
+					setUpMetricValueFun,
+					logger,
+					backup.backupType,
+					stanzaName,
+				)
+			}
+		}
 	}
 }
 
@@ -165,4 +298,12 @@ func getBackupLastDBCountMetrics(config, configIncludePath, stanzaName string, l
 func resetLastBackupMetrics() {
 	pgbrStanzaBackupSinceLastCompletionSecondsMetric.Reset()
 	pgbrStanzaBackupLastDatabasesMetric.Reset()
+	pgbrStanzaBackupLastDurationMetric.Reset()
+	pgbrStanzaBackupLastDatabaseSizeMetric.Reset()
+	pgbrStanzaBackupLastDatabaseBackupSizeMetric.Reset()
+	pgbrStanzaBackupLastRepoBackupSetSizeMetric.Reset()
+	pgbrStanzaBackupLastRepoBackupSetSizeMapMetric.Reset()
+	pgbrStanzaBackupLastRepoBackupSizeMetric.Reset()
+	pgbrStanzaBackupLastRepoBackupSizeMapMetric.Reset()
+	pgbrStanzaBackupLastErrorMetric.Reset()
 }

--- a/backrest/backrest_last_backup_metrics_test.go
+++ b/backrest/backrest_last_backup_metrics_test.go
@@ -245,17 +245,17 @@ pgbackrest_backup_last_databases{backup_type="incr",stanza="demo"} 1
 //nolint:unparam
 func templateLastBackup() lastBackupsStruct {
 	return lastBackupsStruct{
-		backupStruct{"20210607-092423F", "full", time.Unix(1623706322, 0)},
-		backupStruct{"20210607-092423F", "diff", time.Unix(1623706322, 0)},
-		backupStruct{"20210607-092423F", "incr", time.Unix(1623706322, 0)},
+		backupStruct{"20210607-092423F", "full", time.Unix(1623706322, 0), 3, 32230330, 32230330, 2969512, valToPtr(int64(12)), nil, valToPtr(int64(100)), valToPtr(false)},
+		backupStruct{"20210607-092423F", "diff", time.Unix(1623706322, 0), 3, 32230330, 32230330, 2969512, valToPtr(int64(12)), nil, valToPtr(int64(100)), valToPtr(false)},
+		backupStruct{"20210607-092423F", "incr", time.Unix(1623706322, 0), 3, 32230330, 32230330, 2969512, valToPtr(int64(12)), nil, valToPtr(int64(100)), valToPtr(false)},
 	}
 }
 
 //nolint:unparam
 func templateLastBackupDifferent() lastBackupsStruct {
 	return lastBackupsStruct{
-		backupStruct{"20220926-201857F", "full", time.Unix(1623706322, 0)},
-		backupStruct{"20220926-201857F_20220926-201901D", "diff", time.Unix(1623706322, 0)},
-		backupStruct{"20220926-201857F_20220926-202454I", "incr", time.Unix(1623706322, 0)},
+		backupStruct{"20220926-201857F", "full", time.Unix(1623706322, 0), 3, 32230330, 32230330, 2969512, valToPtr(int64(12)), nil, valToPtr(int64(100)), valToPtr(false)},
+		backupStruct{"20220926-201857F_20220926-201901D", "diff", time.Unix(1623706322, 0), 3, 32230330, 32230330, 2969512, valToPtr(int64(12)), nil, valToPtr(int64(100)), valToPtr(false)},
+		backupStruct{"20220926-201857F_20220926-202454I", "incr", time.Unix(1623706322, 0), 3, 32230330, 32230330, 2969512, valToPtr(int64(12)), nil, valToPtr(int64(100)), valToPtr(false)},
 	}
 }

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -16,9 +16,17 @@ import (
 type setUpMetricValueFunType func(metric *prometheus.GaugeVec, value float64, labels ...string) error
 
 type backupStruct struct {
-	backupLabel string
-	backupType  string
-	backupTime  time.Time
+	backupLabel        string
+	backupType         string
+	backupTime         time.Time
+	backupDuration     float64
+	backupDelta        int64
+	backupSize         int64
+	backupRepoDelta    int64
+	backupRepoDeltaMap *int64
+	backupRepoSize     *int64
+	backupRepoSizeMap  *int64
+	backupError        *bool
 }
 type lastBackupsStruct struct {
 	full backupStruct
@@ -184,34 +192,85 @@ func setUpMetricValue(metric *prometheus.GaugeVec, value float64, labels ...stri
 	return nil
 }
 
-func compareLastBackups(backups *lastBackupsStruct, currentBackupTime time.Time, currentBackupLabel, currentBackupType string) {
-	switch currentBackupType {
+func compareLastBackups(backups *lastBackupsStruct, currentBackup backup) {
+	currentBackupTime := time.Unix(currentBackup.Timestamp.Stop, 0)
+	curentBackupDuration := time.Unix(currentBackup.Timestamp.Stop, 0).Sub(time.Unix(currentBackup.Timestamp.Start, 0)).Seconds()
+	currentBackupLabel := currentBackup.Label
+	switch currentBackup.Type {
 	case "full":
 		if currentBackupTime.After(backups.full.backupTime) {
 			backups.full.backupTime = currentBackupTime
 			backups.full.backupLabel = currentBackupLabel
+			backups.full.backupDuration = curentBackupDuration
+			backups.full.backupDelta = currentBackup.Info.Delta
+			backups.full.backupSize = currentBackup.Info.Size
+			backups.full.backupRepoDelta = currentBackup.Info.Repository.Delta
+			backups.full.backupRepoDeltaMap = currentBackup.Info.Repository.DeltaMap
+			backups.full.backupRepoSize = currentBackup.Info.Repository.Size
+			backups.full.backupRepoSizeMap = currentBackup.Info.Repository.SizeMap
+			backups.full.backupError = currentBackup.Error
 		}
 		if currentBackupTime.After(backups.diff.backupTime) {
 			backups.diff.backupTime = currentBackupTime
 			backups.diff.backupLabel = currentBackupLabel
+			backups.diff.backupDuration = curentBackupDuration
+			backups.diff.backupDelta = currentBackup.Info.Delta
+			backups.diff.backupSize = currentBackup.Info.Size
+			backups.diff.backupRepoDelta = currentBackup.Info.Repository.Delta
+			backups.diff.backupRepoDeltaMap = currentBackup.Info.Repository.DeltaMap
+			backups.diff.backupRepoSize = currentBackup.Info.Repository.Size
+			backups.diff.backupRepoSizeMap = currentBackup.Info.Repository.SizeMap
+			backups.diff.backupError = currentBackup.Error
 		}
 		if currentBackupTime.After(backups.incr.backupTime) {
 			backups.incr.backupTime = currentBackupTime
 			backups.incr.backupLabel = currentBackupLabel
+			backups.incr.backupDuration = curentBackupDuration
+			backups.incr.backupDelta = currentBackup.Info.Delta
+			backups.incr.backupSize = currentBackup.Info.Size
+			backups.incr.backupRepoDelta = currentBackup.Info.Repository.Delta
+			backups.incr.backupRepoDeltaMap = currentBackup.Info.Repository.DeltaMap
+			backups.incr.backupRepoSize = currentBackup.Info.Repository.Size
+			backups.incr.backupRepoSizeMap = currentBackup.Info.Repository.SizeMap
+			backups.incr.backupError = currentBackup.Error
 		}
 	case "diff":
 		if currentBackupTime.After(backups.diff.backupTime) {
 			backups.diff.backupTime = currentBackupTime
 			backups.diff.backupLabel = currentBackupLabel
+			backups.diff.backupDuration = curentBackupDuration
+			backups.diff.backupDelta = currentBackup.Info.Delta
+			backups.diff.backupSize = currentBackup.Info.Size
+			backups.diff.backupRepoDelta = currentBackup.Info.Repository.Delta
+			backups.diff.backupRepoDeltaMap = currentBackup.Info.Repository.DeltaMap
+			backups.diff.backupRepoSize = currentBackup.Info.Repository.Size
+			backups.diff.backupRepoSizeMap = currentBackup.Info.Repository.SizeMap
+			backups.diff.backupError = currentBackup.Error
 		}
 		if currentBackupTime.After(backups.incr.backupTime) {
 			backups.incr.backupTime = currentBackupTime
 			backups.incr.backupLabel = currentBackupLabel
+			backups.incr.backupDuration = curentBackupDuration
+			backups.incr.backupDelta = currentBackup.Info.Delta
+			backups.incr.backupSize = currentBackup.Info.Size
+			backups.incr.backupRepoDelta = currentBackup.Info.Repository.Delta
+			backups.incr.backupRepoDeltaMap = currentBackup.Info.Repository.DeltaMap
+			backups.incr.backupRepoSize = currentBackup.Info.Repository.Size
+			backups.incr.backupRepoSizeMap = currentBackup.Info.Repository.SizeMap
+			backups.incr.backupError = currentBackup.Error
 		}
 	case "incr":
 		if currentBackupTime.After(backups.incr.backupTime) {
 			backups.incr.backupTime = currentBackupTime
 			backups.incr.backupLabel = currentBackupLabel
+			backups.incr.backupDuration = curentBackupDuration
+			backups.incr.backupDelta = currentBackup.Info.Delta
+			backups.incr.backupSize = currentBackup.Info.Size
+			backups.incr.backupRepoDelta = currentBackup.Info.Repository.Delta
+			backups.incr.backupRepoDeltaMap = currentBackup.Info.Repository.DeltaMap
+			backups.incr.backupRepoSize = currentBackup.Info.Repository.Size
+			backups.incr.backupRepoSizeMap = currentBackup.Info.Repository.SizeMap
+			backups.incr.backupError = currentBackup.Error
 		}
 	}
 }

--- a/docker_files/run_exporter.sh
+++ b/docker_files/run_exporter.sh
@@ -16,7 +16,7 @@ EXPORTER_COMMAND="/etc/pgbackrest/pgbackrest_exporter \
 [ "${VERBOSE_WAL}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.verbose-wal"
 
 # Check variable for exposing the number of databases in backups.
-[ "${DATABASE_COUNT}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.database-count"
+[ "${DATABASE_COUNT}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.database-count --backrest.database-parallel-processes=${DATABASE_PARALLEL_PROCESSES}"
 
 # Check variable for exposing the number of databases in the latest backups.
 [ "${DATABASE_COUNT_LATEST}" == "true" ] &&  EXPORTER_COMMAND="${EXPORTER_COMMAND} --backrest.database-count-latest"

--- a/e2e_tests/prepare_e2e.sh
+++ b/e2e_tests/prepare_e2e.sh
@@ -12,6 +12,7 @@ PG_DATA="/var/lib/postgresql/13/${PG_CLUSTER}"
 BACKREST_STANZA="demo"
 EXPORTER_COMMAND="/etc/pgbackrest/pgbackrest_exporter \
 --backrest.database-count \
+--backrest.database-parallel-processes=2 \
 --backrest.database-count-latest"
 
 # Enable checksums.

--- a/e2e_tests/run_e2e.sh
+++ b/e2e_tests/run_e2e.sh
@@ -40,18 +40,29 @@ esac
 # A simple test to check the number of metrics.
 # Format: regex for metric | repetitions.
 declare -a REGEX_LIST=(
+    '^pgbackrest_backup_databases{.*,backup_type="full",.*} 2|2'
+    '^pgbackrest_backup_databases{.*,backup_type="diff",.*,repo_key="2".*} 2|1'
     '^pgbackrest_backup_delta_bytes{.*}|3'
     '^pgbackrest_backup_duration_seconds{.*}|3'
     '^pgbackrest_backup_error_status{.*,backup_type="full",.*} 0$|2'
     '^pgbackrest_backup_error_status{.*,backup_type="diff",.*,repo_key="2".*} 1$|1'
-    '^pgbackrest_backup_since_last_completion_seconds{.*}|3'
-    '^pgbackrest_backup_databases{.*,backup_type="full",.*} 2|2'
-    '^pgbackrest_backup_databases{.*,backup_type="diff",.*,repo_key="2".*} 2|1'
-    '^pgbackrest_backup_last_databases{.*}|3'
     '^pgbackrest_backup_info{.*,block_incr="n",.*} 1$|1'
     '^pgbackrest_backup_info{.*,block_incr="y",.*} 1$|2'
+    '^pgbackrest_backup_last_databases{.*}|3'
+    '^pgbackrest_backup_last_delta_bytes{.*}|3'
+    '^pgbackrest_backup_last_duration_seconds{.*}|3'
+    '^pgbackrest_backup_last_error_status{backup_type="full",.*} 0|1'
+    '^pgbackrest_backup_last_error_status{backup_type="diff",.*} 1|1'
+    '^pgbackrest_backup_last_error_status{backup_type="incr",.*} 1|1'
+    '^pgbackrest_backup_last_repo_delta_bytes{.*}|3'
+    '^pgbackrest_backup_last_repo_delta_map_bytes{.*}|3'
+    '^pgbackrest_backup_last_repo_size_map_bytes{.*}|3'
+    '^pgbackrest_backup_last_size_bytes{.*}|3'
     '^pgbackrest_backup_repo_delta_bytes{.*}|3'
+    '^pgbackrest_backup_repo_delta_map_bytes{.*}|2'
     '^pgbackrest_backup_repo_size_bytes{.*}|1'
+    '^pgbackrest_backup_repo_size_map_bytes{.*}|2'
+    '^pgbackrest_backup_since_last_completion_seconds{.*}|3'
     '^pgbackrest_backup_size_bytes{.*}|3'
     '^pgbackrest_exporter_info{.*} 1$|1'
     '^pgbackrest_repo_status{.*,repo_key="1".*} 0$|1'
@@ -59,8 +70,6 @@ declare -a REGEX_LIST=(
     '^pgbackrest_stanza_status{.*} 0$|1'
     '^pgbackrest_wal_archive_status{.*,repo_key="1",.*}|1'
     '^pgbackrest_wal_archive_status{.*,repo_key="2",.*}|1'
-    '^pgbackrest_backup_repo_size_map_bytes{.*}|2'
-    '^pgbackrest_backup_repo_delta_map_bytes{.*}|2'
 )
 
 # Check results.


### PR DESCRIPTION
Closed #55.

* Added new metrics for last backups:
  - pgbackrest_backup_last_duration_seconds
  - pgbackrest_backup_last_size_bytes
  - pgbackrest_backup_last_delta_bytes
  - pgbackrest_backup_last_repo_size_bytes
  - pgbackrest_backup_last_repo_size_map_bytes
  - pgbackrest_backup_last_repo_delta_bytes
  - pgbackrest_backup_last_repo_delta_map_bytes
  - pgbackrest_backup_last_error_status

* Added flag `--backrest.database-parallel-processes` to Docker image.