### PR TITLE
Switch to go 1.20. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
       build_platforms: "linux/amd64,linux/arm64"
     steps:
       - name: Set up go 1.20
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.20"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build and test
         run: |
@@ -30,16 +30,16 @@ jobs:
           GOFLAGS: "-mod=vendor"
           TZ: "Etc/UTC"
 
-      - name: Install golangci-lint and goveralls
-        run: |
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.50.1
-          GO111MODULE=off go get -u github.com/mattn/goveralls
-
       - name: Run linters
-        run: $GITHUB_WORKSPACE/golangci-lint run --out-format=github-actions
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.53.3
         env:
-          GOFLAGS: "-mod=vendor"
           TZ: "Etc/UTC"
+
+      - name: Install goveralls
+        run: |
+          GO111MODULE=off go get -u github.com/mattn/goveralls
 
       - name: Submit coverage
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverage.out
@@ -47,11 +47,11 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
@@ -173,13 +173,13 @@ jobs:
       goreleaser_version: "v1.13.1"
     steps:
       - name: Set up go 1.20
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: "1.20"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get ref
         id: vars
@@ -187,14 +187,14 @@ jobs:
           echo ::set-output name=ref::$(echo ${GITHUB_REF} | cut -d'/' -f3)
 
       - name: Check GoReleaser config
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: ${{ env.goreleaser_version }}
           args: check
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           distribution: goreleaser

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       docker_backrest_version: "v0.19"
       build_platforms: "linux/amd64,linux/arm64"
     steps:
-      - name: Set up go 1.18
+      - name: Set up go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: "1.20"
         id: go
 
       - name: Checkout
@@ -172,10 +172,10 @@ jobs:
     env: 
       goreleaser_version: "v1.13.1"
     steps:
-      - name: Set up go 1.18
+      - name: Set up go 1.20
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: "1.20"
         id: go
 
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env: 
-      goreleaser_version: "v1.13.1"
+      goreleaser_version: "v1.18.2"
     steps:
       - name: Set up go 1.20
         uses: actions/setup-go@v3
@@ -199,6 +199,6 @@ jobs:
         with:
           distribution: goreleaser
           version: ${{ env.goreleaser_version }}
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,19 +21,16 @@ archives:
     files:
       - LICENSE
     format: tar.gz
-    name_template: "{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+    name_template: >-
+      {{ .Binary }}-{{ .Version }}-{{ if eq .Os "darwin" }}macos{{ else }}{{ .Os }}{{ end }}-{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}
     wrap_in_directory: true
-    replacements:
-      amd64: x86_64
-      darwin: macos
+    rlcp: true
 
 nfpms:
   - id: pgbackrest_exporter
     package_name: pgbackrest_exporter
     builds:
       - pgbackrest_exporter
-    replacements:
-      amd64: x86_64
     homepage: https://github.com/woblerr/pgbackrest_exporter
     maintainer: Anton Kurochkin
     description: Prometheus exporter for pgBackRest
@@ -42,7 +39,7 @@ nfpms:
       - deb
       - rpm
     bindir: /usr/bin
-    file_name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    file_name_template: '{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}'
     contents:
       - src: pgbackrest_exporter.service.template
         dst: /etc/systemd/system/pgbackrest_exporter.service

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BACKREST_VERSION="2.46"
 ARG DOCKER_BACKREST_VERSION="v0.19"
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.18-buster AS builder
+FROM golang:1.20-bookworm AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,12 +1,14 @@
 FROM goreleaser/goreleaser as builder
 WORKDIR /build
 COPY . /build
-RUN goreleaser release --snapshot --skip-publish --rm-dist
+RUN goreleaser release --snapshot --skip-publish --clean
 
 FROM alpine
 COPY --from=builder /build/dist/ /dist/
 RUN mkdir -p /artifacts && \
     cp /dist/*.tar.gz /artifacts/ && \
+    cp /dist/*.rpm /artifacts/ && \
+    cp /dist/*.deb /artifacts/ && \
     cp /dist/*.txt /artifacts/ && \
     ls -la /artifacts/*
 CMD ["sleep", "150"]

--- a/e2e_tests/Dockerfile
+++ b/e2e_tests/Dockerfile
@@ -2,7 +2,7 @@ ARG BACKREST_VERSION="2.46"
 ARG DOCKER_BACKREST_VERSION="v0.19"
 ARG PG_VERSION="13"
 
-FROM golang:1.18-buster AS builder
+FROM golang:1.20-bookworm AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/pgbackrest_exporter
 
-go 1.18
+go 1.20
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2


### PR DESCRIPTION
* Switched to `go 1.20`.
* Updated actions versions in CI.
* Updated golangci-lint version to `v1.53.3`.
* Updated goreleaser version to `v1.18.2`.