### PR TITLE
Add exporter get data status metric.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 test-e2e:
 	@echo "Run end-to-end tests for $(APP_NAME)"
 	@if [ -n "$(DOCKER_CONTAINER_E2E)" ]; then docker rm -f "$(DOCKER_CONTAINER_E2E)"; fi;
-	DOCKER_BUILDKIT=1 docker build --pull -f e2e_tests/Dockerfile --build-arg BACKREST_VERSION=$(BACKREST_VERSION) --build-arg DOCKER_BACKREST_VERSION=$(DOCKER_BACKREST_VERSION) -t $(APP_NAME)_e2e .
+	DOCKER_BUILDKIT=1 docker build --pull -f e2e_tests/Dockerfile --build-arg REPO_BUILD_TAG=$(BRANCH)-$(GIT_REV) --build-arg BACKREST_VERSION=$(BACKREST_VERSION) --build-arg DOCKER_BACKREST_VERSION=$(DOCKER_BACKREST_VERSION) -t $(APP_NAME)_e2e .
 	$(call e2e_basic)
 	$(call e2e_tls_auth,/e2e_tests/web_config_empty.yml,false,false)
 	$(call e2e_tls_auth,/e2e_tests/web_config_TLS_noAuth.yml,true,false)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The metrics are collected based on result of `pgbackrest info --output json` com
 | Metric | Description |  Labels | Additional Info |
 | ----------- | ------------------ | ------------- | --------------- |
 | `pgbackrest_exporter_info` | information about pgBackRest exporter | version | |
+| `pgbackrest_exporter_status` | pgBackRest exporter get data status | stanza | Values description:<br> `0` - errors occurred when fetching information from pgBackRest,<br> `1` - information successfully fetched from pgBackRest. |
 
 ### Additional description of metrics
 
@@ -75,7 +76,11 @@ For `pgbackrest_*_last_*` metrics for differential backups (`backup_type="diff"`
 
 For `pgbackrest_*_last_*` metrics for incremental backups (`backup_type="incr"`) the following logic is applied:
 * if the last backup was full or differential, the metric will take full or differential backup value;
-* otherwise, the value will be set. 
+* otherwise, the value will be set.
+
+For `pgbackrest_exporter_status` metric the following logic is applied:
+* if the information is collected for all available stanzas, the `stanza` label value will be `all-stanzas`;
+* otherwise, the stanza name will be set.
 
 Metric `pgbackrest_backup_annotations` is set only for backups that have annotations.
 If there are no annotations, the metric won't be set for this backup.

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -69,8 +69,8 @@ func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []s
 	// If stanza not set - perform a single loop step to get metrics for all stanzas.
 	for _, stanza := range stanzas {
 		// Flag to check if pgBackRest get info for this stanza.
-		// By default it's set to true.
-		// If we get error form pgBackRest when getting info for stanza, flag will be set to false.
+		// By default, it's set to true.
+		// If we get an error from pgBackRest when getting info for stanza, flag will be set to false.
 		getDataSuccessStatus := true
 		// Check that stanza from the include list is not in the exclude list.
 		// If stanza not set - checking for entry into the exclude list will be performed later.
@@ -121,7 +121,7 @@ func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []s
 		} else {
 			// When stanza is specified in both include and exclude lists, a warning is displayed in the log
 			// and data for this stanza is not collected.
-			// It is necessary to set zero metric value for such a stanza.
+			// It is necessary to set zero metric value for this stanza.
 			getDataSuccessStatus = false
 			getExporterStatusMetrics(stanza, getDataSuccessStatus, setUpMetricValue, logger)
 			level.Warn(logger).Log("msg", "Stanza is specified in include and exclude lists", "stanza", stanza)

--- a/backrest/backrest_exporter_metrics.go
+++ b/backrest/backrest_exporter_metrics.go
@@ -6,11 +6,18 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var pgbrExporterInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Name: "pgbackrest_exporter_info",
-	Help: "Information about pgBackRest exporter.",
-},
-	[]string{"version"})
+var (
+	pgbrExporterInfoMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_exporter_info",
+		Help: "Information about pgBackRest exporter.",
+	},
+		[]string{"version"})
+	pgbrExporterStatusMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "pgbackrest_exporter_status",
+		Help: "pgBackRest exporter get data status.",
+	},
+		[]string{"stanza"})
+)
 
 // Set exporter info metrics:
 //   - pgbackrest_exporter_info
@@ -23,4 +30,27 @@ func getExporterMetrics(exporterVer string, setUpMetricValueFun setUpMetricValue
 		logger,
 		exporterVer,
 	)
+}
+
+// Set exporter metrics:
+//   - pgbackrest_exporter_status
+func getExporterStatusMetrics(stanzaName string, getDataStatus bool, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
+	// If the information is collected for all available stanzas,
+	// the value of the label 'stanza' will be 'all-stanzas',
+	// otherwise the stanza name will be set.
+	if stanzaName == "" {
+		stanzaName = "all-stanzas"
+	}
+	setUpMetric(
+		pgbrExporterStatusMetric,
+		"pgbackrest_exporter_status",
+		convertBoolToFloat64(getDataStatus),
+		setUpMetricValueFun,
+		logger,
+		stanzaName,
+	)
+}
+
+func resetExporterMetrics() {
+	pgbrExporterStatusMetric.Reset()
 }

--- a/backrest/backrest_exporter_metrics_test.go
+++ b/backrest/backrest_exporter_metrics_test.go
@@ -90,3 +90,98 @@ func TestGetExporterInfoErrorsAndDebugs(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExporterStatusMetrics(t *testing.T) {
+	type args struct {
+		stanzaName          string
+		getDataStatus       bool
+		testText            string
+		setUpMetricValueFun setUpMetricValueFunType
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"GetExporterStatusGood",
+			args{
+				"test",
+				true,
+				`# HELP pgbackrest_exporter_status pgBackRest exporter get data status.
+# TYPE pgbackrest_exporter_status gauge
+pgbackrest_exporter_status{stanza="test"} 1
+`,
+				setUpMetricValue,
+			},
+		},
+		{"GetExporterStatusBad",
+			args{
+				"test",
+				false,
+				`# HELP pgbackrest_exporter_status pgBackRest exporter get data status.
+# TYPE pgbackrest_exporter_status gauge
+pgbackrest_exporter_status{stanza="test"} 0
+`,
+				setUpMetricValue,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetExporterMetrics()
+			getExporterStatusMetrics(tt.args.stanzaName, tt.args.getDataStatus, tt.args.setUpMetricValueFun, logger)
+			reg := prometheus.NewRegistry()
+			reg.MustRegister(pgbrExporterStatusMetric)
+			metricFamily, err := reg.Gather()
+			if err != nil {
+				fmt.Println(err)
+			}
+			out := &bytes.Buffer{}
+			for _, mf := range metricFamily {
+				if _, err := expfmt.MetricFamilyToText(out, mf); err != nil {
+					panic(err)
+				}
+			}
+			if tt.args.testText != out.String() {
+				t.Errorf("\nVariables do not match:\n%s\nwant:\n%s", tt.args.testText, out.String())
+			}
+		})
+	}
+}
+
+func TestGetExporterStatusErrorsAndDebugs(t *testing.T) {
+	type args struct {
+		stanzaName          string
+		getDataStatus       bool
+		setUpMetricValueFun setUpMetricValueFunType
+		errorsCount         int
+		debugsCount         int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{"GetExporterInfoLogError",
+			args{
+				`test`,
+				true,
+				fakeSetUpMetricValue,
+				1,
+				1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			lc := log.NewLogfmtLogger(out)
+			getExporterStatusMetrics(tt.args.stanzaName, tt.args.getDataStatus, tt.args.setUpMetricValueFun, lc)
+			errorsOutputCount := strings.Count(out.String(), "level=error")
+			debugsOutputCount := strings.Count(out.String(), "level=debug")
+			if tt.args.errorsCount != errorsOutputCount || tt.args.debugsCount != debugsOutputCount {
+				t.Errorf("\nVariables do not match:\nerrors=%d, debugs=%d\nwant:\nerrors=%d, debugs=%d",
+					tt.args.errorsCount, tt.args.debugsCount,
+					errorsOutputCount, debugsOutputCount)
+			}
+		})
+	}
+}

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -355,6 +355,7 @@ func resetMetrics() {
 	resetBackupMetrics()
 	resetLastBackupMetrics()
 	resetWALMetrics()
+	resetExporterMetrics()
 }
 
 func checkBackupDatabaseRef(backupData []stanza) bool {

--- a/e2e_tests/run_e2e.sh
+++ b/e2e_tests/run_e2e.sh
@@ -71,6 +71,7 @@ declare -a REGEX_LIST=(
     '^pgbackrest_backup_since_last_completion_seconds{.*}|3'
     '^pgbackrest_backup_size_bytes{.*}|3'
     '^pgbackrest_exporter_info{.*} 1$|1'
+    '^pgbackrest_exporter_status{stanza="all-stanzas"} 1$|1'
     '^pgbackrest_repo_status{.*,repo_key="1".*} 0$|1'
     '^pgbackrest_repo_status{.*,repo_key="2".*} 0$|1'
     '^pgbackrest_stanza_backup_compete_bytes{.*} 0$|1'


### PR DESCRIPTION
Added pgBackRest exporter get data status metric:
- `pgbackrest_exporter_status`.

If the information is collected for all available stanzas, the `stanza` label value will be `all-stanzas`, otherwise the stanza name will be set.

Closes #71.