### PR TITLE
Fix incorrect latest metrics when filtering backup types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,6 @@ For `pgbackrest_exporter_status` metric the following logic is applied:
 * if the information is collected for all available stanzas, the `stanza` label value will be `all-stanzas`;
 * otherwise, the stanza name will be set.
 
-Metric `pgbackrest_backup_annotations` is set only for backups that have annotations.
-If there are no annotations, the metric won't be set for this backup.
-
 If `pgbackrest_stanza_lock_status` metric is `1`, than one of the commands is running for stanza: `backup`, `expire` or `stanza-*`.
 With a very high probability it is `backup/expire`.
 
@@ -219,7 +216,8 @@ Custom `backup type` for collecting metrics can be specified via `--backrest.bac
 For example, `--backrest.backup-type=full`.<br>
 For this case, metrics will be collected only for `full` backups.<br>
 This flag works for `pgBackRest >= v2.38`.<br>
-When parameter value is `incr` or `diff`, the following metrics will not be collected: `pgbackrest_backup_since_last_completion_seconds`, `pgbackrest_backup_last_databases`.<br>
+When parameter value is `incr` or `diff`, all `pgbackrest_backup_last_*` metrics will not be collected.<br>
+When parameter value is `full`, the metrics will be as if the last backup was `full` (i.e. the same for `diff` and `incr`).<br>
 For earlier pgBackRest versions there will be an error like: `option 'type' not valid for command 'info'`.
 
 When flag `--backrest.database-count` is specified - information about the number of databases in backup is collected.<br>

--- a/backrest/backrest_exporter.go
+++ b/backrest/backrest_exporter.go
@@ -101,7 +101,12 @@ func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []s
 					getWALMetrics(singleStanza.Name, singleStanza.Archive, singleStanza.DB, verboseWAL, setUpMetricValue, logger)
 					// Last backups for current stanza
 					lastBackups := getBackupMetrics(singleStanza.Name, singleStanza.Backup, singleStanza.DB, setUpMetricValue, logger)
-					getBackupLastMetrics(singleStanza.Name, lastBackups, currentUnixTime, setUpMetricValue, logger)
+					// If full backup exists, the values of metrics for differential and
+					// incremental backups also will be set.
+					// If not - metrics won't be set.
+					if !lastBackups.full.backupTime.IsZero() {
+						getBackupLastMetrics(singleStanza.Name, lastBackups, currentUnixTime, setUpMetricValue, logger)
+					}
 					// If the calculation of the number of databases in backups is enabled.
 					// Information about number of databases in specific backup has appeared since pgBackRest v2.41.
 					// In versions < v2.41 this is missing and the metric will be set to 0.
@@ -111,7 +116,7 @@ func GetPgBackRestInfo(config, configIncludePath, backupType string, stanzas []s
 					// If the calculation of the number of databases in latest backups is enabled.
 					// Information about number of databases in specific backup has appeared since pgBackRest v2.41.
 					// In versions < v2.41 this is missing and the metric will be set to 0.
-					if backupDBCountLatest {
+					if backupDBCountLatest && !lastBackups.full.backupTime.IsZero() {
 						getBackupLastDBCountMetrics(config, configIncludePath, singleStanza.Name, lastBackups, setUpMetricValue, logger)
 					}
 				}

--- a/backrest/backrest_last_backup_metrics.go
+++ b/backrest/backrest_last_backup_metrics.go
@@ -123,124 +123,119 @@ var (
 //   - pgbackrest_backup_last_error_status
 //   - pgbackrest_backup_last_annotations
 func getBackupLastMetrics(stanzaName string, lastBackups lastBackupsStruct, currentUnixTime int64, setUpMetricValueFun setUpMetricValueFunType, logger log.Logger) {
-	// If full backup exists, the values of metrics for differential and
-	// incremental backups also will be set.
-	// If not - metrics won't be set.
-	if !lastBackups.full.backupTime.IsZero() {
-		for _, backup := range []backupStruct{lastBackups.full, lastBackups.diff, lastBackups.incr} {
-			// Repo backup map size for last backups.
-			setUpMetric(
-				pgbrStanzaBackupLastRepoBackupSetSizeMapMetric,
-				"pgbackrest_backup_last_repo_size_map_bytes",
-				convertInt64PointerToFloat64(backup.backupRepoSizeMap),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Repo backup delta map size for last backups.
-			setUpMetric(
-				pgbrStanzaBackupLastRepoBackupSizeMapMetric,
-				"pgbackrest_backup_last_repo_delta_map_bytes",
-				convertInt64PointerToFloat64(backup.backupRepoDeltaMap),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Seconds since the last completed backups.
-			setUpMetric(
-				pgbrStanzaBackupSinceLastCompletionSecondsMetric,
-				"pgbackrest_backup_since_last_completion_seconds",
-				time.Unix(currentUnixTime, 0).Sub(backup.backupTime).Seconds(),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Backup durations in seconds for last backups.
-			setUpMetric(
-				pgbrStanzaBackupLastDurationMetric,
-				"pgbackrest_backup_last_duration_seconds",
-				backup.backupDuration,
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Database size for last backups.
-			setUpMetric(
-				pgbrStanzaBackupLastDatabaseSizeMetric,
-				"pgbackrest_backup_last_size_bytes",
-				float64(backup.backupSize),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Database backup size for last backups.
-			setUpMetric(
-				pgbrStanzaBackupLastDatabaseBackupSizeMetric,
-				"pgbackrest_backup_last_delta_bytes",
-				float64(backup.backupDelta),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Repo backup set size.
-			setUpMetric(
-				pgbrStanzaBackupLastRepoBackupSetSizeMetric,
-				"pgbackrest_backup_last_repo_size_bytes",
-				convertInt64PointerToFloat64(backup.backupRepoSize),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Repo backup size.
-			setUpMetric(
-				pgbrStanzaBackupLastRepoBackupSizeMetric,
-				"pgbackrest_backup_last_repo_delta_bytes",
-				float64(backup.backupRepoDelta),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Backup error status.
-			setUpMetric(
-				pgbrStanzaBackupLastErrorMetric,
-				"pgbackrest_backup_last_error_status",
-				convertBoolPointerToFloat64(backup.backupError),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-			// Number of backup annotations.
-			// Information about number of annotations in backup has appeared since pgBackRest v2.41.
-			// If there are no annotations, the metric will be set to 0 for this backup.
-			setUpMetric(
-				pgbrStanzaBackupLastAnnotationsMetric,
-				"pgbackrest_backup_last_annotations",
-				convertAnnotationPointerToFloat64(backup.backupAnnotation),
-				setUpMetricValueFun,
-				logger,
-				backup.backupType,
-				backup.backupBlockIncr,
-				stanzaName,
-			)
-		}
+	for _, backup := range []backupStruct{lastBackups.full, lastBackups.diff, lastBackups.incr} {
+		// Repo backup map size for last backups.
+		setUpMetric(
+			pgbrStanzaBackupLastRepoBackupSetSizeMapMetric,
+			"pgbackrest_backup_last_repo_size_map_bytes",
+			convertInt64PointerToFloat64(backup.backupRepoSizeMap),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Repo backup delta map size for last backups.
+		setUpMetric(
+			pgbrStanzaBackupLastRepoBackupSizeMapMetric,
+			"pgbackrest_backup_last_repo_delta_map_bytes",
+			convertInt64PointerToFloat64(backup.backupRepoDeltaMap),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Seconds since the last completed backups.
+		setUpMetric(
+			pgbrStanzaBackupSinceLastCompletionSecondsMetric,
+			"pgbackrest_backup_since_last_completion_seconds",
+			time.Unix(currentUnixTime, 0).Sub(backup.backupTime).Seconds(),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Backup durations in seconds for last backups.
+		setUpMetric(
+			pgbrStanzaBackupLastDurationMetric,
+			"pgbackrest_backup_last_duration_seconds",
+			backup.backupDuration,
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Database size for last backups.
+		setUpMetric(
+			pgbrStanzaBackupLastDatabaseSizeMetric,
+			"pgbackrest_backup_last_size_bytes",
+			float64(backup.backupSize),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Database backup size for last backups.
+		setUpMetric(
+			pgbrStanzaBackupLastDatabaseBackupSizeMetric,
+			"pgbackrest_backup_last_delta_bytes",
+			float64(backup.backupDelta),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Repo backup set size.
+		setUpMetric(
+			pgbrStanzaBackupLastRepoBackupSetSizeMetric,
+			"pgbackrest_backup_last_repo_size_bytes",
+			convertInt64PointerToFloat64(backup.backupRepoSize),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Repo backup size.
+		setUpMetric(
+			pgbrStanzaBackupLastRepoBackupSizeMetric,
+			"pgbackrest_backup_last_repo_delta_bytes",
+			float64(backup.backupRepoDelta),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Backup error status.
+		setUpMetric(
+			pgbrStanzaBackupLastErrorMetric,
+			"pgbackrest_backup_last_error_status",
+			convertBoolPointerToFloat64(backup.backupError),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
+		// Number of backup annotations.
+		// Information about number of annotations in backup has appeared since pgBackRest v2.41.
+		// If there are no annotations, the metric will be set to 0 for this backup.
+		setUpMetric(
+			pgbrStanzaBackupLastAnnotationsMetric,
+			"pgbackrest_backup_last_annotations",
+			convertAnnotationPointerToFloat64(backup.backupAnnotation),
+			setUpMetricValueFun,
+			logger,
+			backup.backupType,
+			backup.backupBlockIncr,
+			stanzaName,
+		)
 	}
 }
 


### PR DESCRIPTION
When `--backrest.backup-type` flag is specified, if parameter value is `incr` or `diff`, all `"pgbackrest_backup_last_*` metrics will not be collected.

When parameter value is `full`, the metrics will be as if the last backup was `full` (i.e. the same for `diff` and `incr`).<br>

Also removed outdate info about  `pgbackrest_backup_annptations` metric.