### PR TITLE
Bind to localhost by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ usage: pgbackrest_exporter [<flags>]
 Flags:
   -h, --[no-]help                Show context-sensitive help (also try --help-long and --help-man).
       --web.endpoint="/metrics"  Endpoint used for metrics.
-      --web.listen-address=:9854 ...  
+      --web.listen-address=127.0.0.1:9854 ...
                                  Addresses on which to expose metrics and web interface. Repeatable for multiple addresses.
       --web.config.file=""       [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
       --collect.interval=600     Collecting metrics interval in seconds.

--- a/docker_files/run_exporter.sh
+++ b/docker_files/run_exporter.sh
@@ -5,7 +5,7 @@ set -e
 # Basic command for execute pgbackrest_exporter.
 EXPORTER_COMMAND="/etc/pgbackrest/pgbackrest_exporter \
 --web.endpoint=${EXPORTER_ENDPOINT} \
---web.listen-address=:${EXPORTER_PORT} \
+--web.listen-address=127.0.0.1:${EXPORTER_PORT} \
 --web.config.file=${EXPORTER_CONFIG} \
 --collect.interval=${COLLECT_INTERVAL} \
 --backrest.stanza-include=${STANZA_INCLUDE} \

--- a/pgbackrest_exporter.service.template
+++ b/pgbackrest_exporter.service.template
@@ -6,9 +6,9 @@ Type=simple
 Environment="EXPORTER_ENDPOINT=/metrics"
 Environment="EXPORTER_PORT=9854"
 Environment="COLLECT_INTERVAL=600"
-ExecStart=/usr/bin/pgbackrest_exporter --web.endpoint=${EXPORTER_ENDPOINT} --web.listen-address=:${EXPORTER_PORT} --collect.interval=${COLLECT_INTERVAL}
+ExecStart=/usr/bin/pgbackrest_exporter --web.endpoint=${EXPORTER_ENDPOINT} --web.listen-address=127.0.0.1:${EXPORTER_PORT} --collect.interval=${COLLECT_INTERVAL}
 Restart=always
 RestartSec=5s
 
 [Install]
-WantedBy=multi-user.target 
+WantedBy=multi-user.target


### PR DESCRIPTION
When running a vanilla configuration, it exposes the metrics port to the world. I thought it would be a better practice to have it bind to the localhost by default.