### PR TITLE
Use $ARGS instead of ${ARGS}.

### DIFF
--- a/pgbackrest_exporter.service.template
+++ b/pgbackrest_exporter.service.template
@@ -5,7 +5,7 @@ Description=pgbackrest_exporter
 Type=simple
 Environment="ARGS=--web.endpoint=/metrics --web.listen-address=:9854 --collect.interval=600"
 EnvironmentFile=-/etc/default/pgbackrest_exporter
-ExecStart=/usr/bin/pgbackrest_exporter ${ARGS}
+ExecStart=/usr/bin/pgbackrest_exporter $ARGS
 Restart=always
 RestartSec=5s
 


### PR DESCRIPTION
See man for systemd.
In short,  systemd supports environment variable substitution. 
`"${FOO}"`  - as part of a word, or as a word of its own, on the command line, it will be replaced by the value of the environment variable including all whitespace it contains, resulting in a single argument. 
`"$FOO"` -  as a separate word on the command line,  it will be replaced by the value of the environment variable split at whitespace, resulting in zero or more arguments.

Fix #91 