### PR TITLE
Switch to go 1.23.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env: 
-      goreleaser_version: "v1.24.0"
+      goreleaser_version: "v2.5.0"
     steps:
       - name: Set up go 1.23
         uses: actions/setup-go@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       docker_backrest_version: "v0.27"
       build_platforms: "linux/amd64,linux/arm64"
     steps:
-      - name: Set up go 1.21
+      - name: Set up go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
         id: go
 
       - name: Checkout
@@ -172,10 +172,10 @@ jobs:
     env: 
       goreleaser_version: "v1.24.0"
     steps:
-      - name: Set up go 1.21
+      - name: Set up go 1.23
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21"
+          go-version: "1.23"
         id: go
 
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
       build_platforms: "linux/amd64,linux/arm64"
     steps:
       - name: Set up go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build and test
         run: |
@@ -31,15 +31,15 @@ jobs:
           TZ: "Etc/UTC"
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.62.2
         env:
           TZ: "Etc/UTC"
 
       - name: Install goveralls
         run: |
-          GO111MODULE=off go get -u github.com/mattn/goveralls
+          go install github.com/mattn/goveralls@latest
 
       - name: Submit coverage
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/coverage.out
@@ -47,14 +47,16 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
+        run: echo ${BUILDX_PLATFORMS}
+        env:
+          BUILDX_PLATFORMS: ${{ steps.buildx.outputs.platforms }}
 
       - name: Run end-to-end tests
         run: |
@@ -173,13 +175,13 @@ jobs:
       goreleaser_version: "v1.24.0"
     steps:
       - name: Set up go 1.23
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: "1.23"
         id: go
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get ref
         id: vars
@@ -187,14 +189,14 @@ jobs:
           echo ::set-output name=ref::$(echo ${GITHUB_REF} | cut -d'/' -f3)
 
       - name: Check GoReleaser config
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: ${{ env.goreleaser_version }}
           args: check .goreleaser.yml
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         with:
           distribution: goreleaser

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,16 +2,13 @@ run:
   timeout: 5m
   output:
     format: colored-line-number
-  skip-dirs:
-    - vendor
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   revive:
     confidence: 0.1
-  maligned:
-    suggest-new: true
   goconst:
     min-len: 2
     min-occurrences: 2
@@ -34,12 +31,11 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
+    - staticcheck
     - revive
     - govet
     - unconvert
-    - megacheck
-    - gas
+    - gosec
     - gocyclo
     - dupl
     - misspell
@@ -49,7 +45,7 @@ linters:
     - ineffassign
     - stylecheck
     - gochecknoinits
-    - exportloopref
+    - copyloopvar
     - gocritic
     - nakedret
     - gosimple
@@ -58,6 +54,8 @@ linters:
   disable-all: true
 
 issues:
+  exclude-dirs:
+    - vendor
   exclude-rules:
     - path: _test\.go
       linters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,6 @@
 ---
+version: 2
+
 project_name: pgbackrest_exporter
 
 builds:
@@ -50,4 +52,4 @@ release:
   draft: true
 
 changelog:
-  skip: true
+  disable: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BACKREST_VERSION="2.53"
 ARG DOCKER_BACKREST_VERSION="v0.27"
 ARG REPO_BUILD_TAG="unknown"
 
-FROM golang:1.21-bookworm AS builder
+FROM golang:1.23-bookworm AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/Dockerfile.artifacts
+++ b/Dockerfile.artifacts
@@ -1,9 +1,9 @@
-FROM goreleaser/goreleaser:v1.24.0 as builder
+FROM goreleaser/goreleaser:v2.5.0 as builder
 WORKDIR /build
 COPY . /build
-RUN goreleaser release --snapshot --skip-publish --clean
+RUN goreleaser release --snapshot --skip=publish --clean
 
-FROM alpine
+FROM alpine:3.20
 COPY --from=builder /build/dist/ /dist/
 RUN mkdir -p /artifacts && \
     cp /dist/*.tar.gz /artifacts/ && \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 - 2024 woblerr
+Copyright (c) 2021 - 2025 woblerr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/e2e_tests/Dockerfile
+++ b/e2e_tests/Dockerfile
@@ -2,7 +2,7 @@ ARG BACKREST_VERSION="2.53"
 ARG DOCKER_BACKREST_VERSION="v0.27"
 ARG PG_VERSION="16"
 
-FROM golang:1.21-bookworm AS builder
+FROM golang:1.23-bookworm AS builder
 ARG REPO_BUILD_TAG
 COPY . /build
 WORKDIR /build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/woblerr/pgbackrest_exporter
 
-go 1.21
+go 1.23
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
* Switch to go `1.23`.
* Bump goreleaser to `v2.5.0`.
* Bump golangci-lint  to `v1.62.2`, fix linters.
* Bump actions/setup-go to `v5`.
* Bump actions/checkout to `v4`.
* Bump golangci/golangci-lint-action to `v6`.
* Bump docker/setup-qemu-action to `v3`.
* Bump docker/setup-buildx-action to `v3`.
* Bump goreleaser/goreleaser-action to `v6`.
* Update LICENSE for 2025.