### PR TITLE
Clarify description for *_references metrics.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get a dashboard for visualizing the collected metrics, you can use a ready-ma
 | ----------- | ------------------ | ------------- | --------------- |
 | `pgbackrest_backup_annotations` | number of annotations in backup | backup_name, backup_type, database_id, block_incr, repo_key, stanza | |
 | `pgbackrest_backup_databases` | number of databases in backup | backup_name, backup_type, block_incr, database_id, repo_key, stanza | |
-| `pgbackrest_backup_references` | number of references to another backup (backup reference list) | backup_name, backup_type, block_incr, database_id, ref_backup, repo_key, stanza | |
+| `pgbackrest_backup_references` | number of references to other backups (backup reference list) | backup_name, backup_type, block_incr, database_id, ref_backup, repo_key, stanza | |
 | `pgbackrest_backup_duration_seconds` | backup duration in seconds | backup_name, backup_type, block_incr, database_id, repo_key, stanza, start_time, stop_time | |
 | `pgbackrest_backup_error_status` | backup error status | backup_name, backup_type, block_incr, database_id, repo_key, stanza | Values description:<br> `0` - backup doesn't contain page checksum errors,<br> `1` - backup contains one or more page checksum errors. To display the list of errors, you need manually run the command like `pgbackrest info --stanza stanza --set backup_name --repo repo_key`. |
 | `pgbackrest_backup_info` | backup info | backrest_ver, backup_name, backup_type, block_incr, database_id, lsn_start, lsn_stop, pg_version, prior, repo_key, stanza, wal_start, wal_stop | Values description:<br> `1` - info about backup is exist. |
@@ -52,7 +52,7 @@ To get a dashboard for visualizing the collected metrics, you can use a ready-ma
 | `pgbackrest_backup_since_last_completion_seconds` | seconds since the last completed full, differential or incremental backup | backup_type, block_incr, stanza | |
 | `pgbackrest_backup_last_annotations` | number of annotations in the last full, differential or incremental backup | backup_type, block_incr, stanza | |
 | `pgbackrest_backup_last_databases` | number of databases in the last full, differential or incremental backup | backup_type, block_incr, stanza | |
-| `pgbackrest_backup_last_references` | number of references to another backup (backup reference list) in the last full, differential or incremental backup | backup_type, block_incr, ref_backup, stanza | |
+| `pgbackrest_backup_last_references` | number of references to other backups (backup reference list) in the last full, differential or incremental backup | backup_type, block_incr, ref_backup, stanza | |
 | `pgbackrest_backup_last_duration_seconds` | backup duration for the last full, differential or incremental backup | backup_type, block_incr, stanza | |
 | `pgbackrest_backup_last_error_status` | error status in the last full, differential or incremental backup | backup_type, block_incr, stanza | |
 | `pgbackrest_backup_last_delta_bytes` | amount of data in the database to actually backup in the last full, differential or incremental backup | backup_type, block_incr, stanza | |
@@ -187,7 +187,7 @@ Flags:
       --[no-]backrest.database-count-latest  
                                  Exposing the number of databases in the latest backups.
       --[no-]backrest.reference-count  
-                                 Exposing the number of references to another backups (backup reference list).
+                                 Exposing the number of references to other backups (backup reference list).
       --[no-]backrest.verbose-wal  
                                  Exposing additional labels for WAL metrics.
       --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]

--- a/backrest/backrest_backup_metrics.go
+++ b/backrest/backrest_backup_metrics.go
@@ -166,10 +166,10 @@ var (
 			"stanza"})
 	// For json pgBackRest output
 	// "backup":"reference"
-	// Number of references to another backups (backup reference list).
+	// Number of references to other backups (backup reference list).
 	pgbrStanzaBackupReferencesMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pgbackrest_backup_references",
-		Help: "Number of references to another backup (backup reference list).",
+		Help: "Number of references to other backups (backup reference list).",
 	},
 		[]string{
 			// Don't change this order.
@@ -382,7 +382,7 @@ func getBackupMetrics(stanzaName string, backupRefCount bool, backupData []backu
 			strconv.Itoa(backup.Database.RepoKey),
 			stanzaName,
 		)
-		// Number of references to another backup (backup reference list).
+		// Number of references to other backups (backup reference list).
 		// This metric could be a little bit annoying because it will be set for each backup.
 		// For no-last backups, the metric is collected only if the flag is set.
 		// For last backups, the metric is always collected.

--- a/backrest/backrest_backup_metrics_test.go
+++ b/backrest/backrest_backup_metrics_test.go
@@ -42,7 +42,7 @@ pgbackrest_backup_error_status{backup_name="20210607-092423F",backup_type="full"
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
 pgbackrest_backup_info{backrest_ver="2.45",backup_name="20210607-092423F",backup_type="full",block_incr="y",database_id="1",lsn_start="0/2000028",lsn_stop="0/2000100",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
-# HELP pgbackrest_backup_references Number of references to another backup (backup reference list).
+# HELP pgbackrest_backup_references Number of references to other backups (backup reference list).
 # TYPE pgbackrest_backup_references gauge
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="y",database_id="1",ref_backup="diff",repo_key="1",stanza="demo"} 0
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="y",database_id="1",ref_backup="full",repo_key="1",stanza="demo"} 0
@@ -187,7 +187,7 @@ pgbackrest_backup_error_status{backup_name="20210607-092423F",backup_type="full"
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
 pgbackrest_backup_info{backrest_ver="2.41",backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",lsn_start="0/2000028",lsn_stop="0/2000100",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
-# HELP pgbackrest_backup_references Number of references to another backup (backup reference list).
+# HELP pgbackrest_backup_references Number of references to other backups (backup reference list).
 # TYPE pgbackrest_backup_references gauge
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="diff",repo_key="1",stanza="demo"} 0
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="full",repo_key="1",stanza="demo"} 0
@@ -320,7 +320,7 @@ pgbackrest_backup_error_status{backup_name="20210607-092423F",backup_type="full"
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
 pgbackrest_backup_info{backrest_ver="2.41",backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",lsn_start="0/2000028",lsn_stop="0/2000100",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
-# HELP pgbackrest_backup_references Number of references to another backup (backup reference list).
+# HELP pgbackrest_backup_references Number of references to other backups (backup reference list).
 # TYPE pgbackrest_backup_references gauge
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="diff",repo_key="1",stanza="demo"} 0
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="full",repo_key="1",stanza="demo"} 0
@@ -457,7 +457,7 @@ pgbackrest_backup_error_status{backup_name="20210607-092423F",backup_type="full"
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
 pgbackrest_backup_info{backrest_ver="2.35",backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",lsn_start="-",lsn_stop="-",pg_version="13",prior="",repo_key="1",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
-# HELP pgbackrest_backup_references Number of references to another backup (backup reference list).
+# HELP pgbackrest_backup_references Number of references to other backups (backup reference list).
 # TYPE pgbackrest_backup_references gauge
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="diff",repo_key="1",stanza="demo"} 0
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="full",repo_key="1",stanza="demo"} 0
@@ -589,7 +589,7 @@ pgbackrest_backup_error_status{backup_name="20210607-092423F",backup_type="full"
 # HELP pgbackrest_backup_info Backup info.
 # TYPE pgbackrest_backup_info gauge
 pgbackrest_backup_info{backrest_ver="2.31",backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",lsn_start="-",lsn_stop="-",pg_version="13",prior="",repo_key="0",stanza="demo",wal_start="000000010000000000000002",wal_stop="000000010000000000000002"} 1
-# HELP pgbackrest_backup_references Number of references to another backup (backup reference list).
+# HELP pgbackrest_backup_references Number of references to other backups (backup reference list).
 # TYPE pgbackrest_backup_references gauge
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="diff",repo_key="0",stanza="demo"} 0
 pgbackrest_backup_references{backup_name="20210607-092423F",backup_type="full",block_incr="n",database_id="1",ref_backup="full",repo_key="0",stanza="demo"} 0

--- a/backrest/backrest_last_backup_metrics.go
+++ b/backrest/backrest_last_backup_metrics.go
@@ -100,7 +100,7 @@ var (
 	// For json pgBackRest output
 	pgbrStanzaBackupLastReferencesMetric = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "pgbackrest_backup_last_references",
-		Help: "Number of references to another backup (backup reference list) in the last full, differential or incremental backup.",
+		Help: "Number of references to other backups (backup reference list) in the last full, differential or incremental backup.",
 	},
 		[]string{
 			// Don't change this order.
@@ -247,7 +247,7 @@ func getBackupLastMetrics(stanzaName string, lastBackups lastBackupsStruct, curr
 			backup.backupBlockIncr,
 			stanzaName,
 		)
-		// Number of references to another backup (backup reference list).
+		// Number of references to other backups (backup reference list).
 		// For no-last backups, the metric is collected only if the flag is set.
 		// For last backups, the metric is always collected.
 		processBackupReferencesCount(

--- a/backrest/backrest_parser.go
+++ b/backrest/backrest_parser.go
@@ -405,7 +405,7 @@ func processSpecificBackupData(config, configIncludePath, stanzaName, backupLabe
 	)
 }
 
-// processBackupReferencesCount processes the number of references to another backup (backup reference list).
+// processBackupReferencesCount processes the number of references to other backups (backup reference list).
 func processBackupReferencesCount(backupReference []string, metricName string, metric *prometheus.GaugeVec, setUpMetricValueFun setUpMetricValueFunType, logger *slog.Logger, addLabels ...string) {
 	refListTotal, err := getBackupReferencesTotal(backupReference)
 	if err != nil {

--- a/pgbackrest_exporter.go
+++ b/pgbackrest_exporter.go
@@ -66,7 +66,7 @@ func main() {
 		).Default("false").Bool()
 		backrestBackupReferenceCount = kingpin.Flag(
 			"backrest.reference-count",
-			"Exposing the number of references to another backups (backup reference list).",
+			"Exposing the number of references to other backups (backup reference list).",
 		).Default("false").Bool()
 		backrestVerboseWAL = kingpin.Flag(
 			"backrest.verbose-wal",
@@ -134,7 +134,7 @@ func main() {
 	}
 	if *backrestBackupReferenceCount {
 		logger.Info(
-			"Exposing the number of references to another backups (backup reference list)",
+			"Exposing the number of references to other backups (backup reference list)",
 			"reference-count", *backrestBackupReferenceCount)
 	}
 	if *backrestBackupDBCount {


### PR DESCRIPTION
The phrasing is standardized to `references to other backups (backup reference list)`.  The documentation and tests have been updated.

For  `pgbackrest_backup_references` metric the `HELP` description  has changed to 
```
# HELP pgbackrest_backup_references Number of references to other backups (backup reference list).
```

For  `pgbackrest_backup_last_references` metric the `HELP` description  has changed to 
```
# HELP pgbackrest_backup_last_references Number of references to other backups (backup reference list) in the last full, differential or incremental backup.
```

